### PR TITLE
Designated user

### DIFF
--- a/src/test/java/com/hocs/test/glue/LoginStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/LoginStepDefs.java
@@ -137,6 +137,43 @@ public class LoginStepDefs extends Page {
         }
     }
 
+    @Given("^that I have navigated to the Management UI as the designated user$")
+    public void iHaveNavigatedToTheManagementUIAsTheDesignatedUser() {
+
+        String user = System.getProperty("user");
+
+        if (user == null) {
+            System.out.println("User parameter not set. Defaulting to 'EAMON'");
+            user = "EAMON";
+        }
+
+        navigateToManagementUI();
+
+        if (isElementDisplayed($(loginPage.usernameField))) {
+            System.out.println("On fresh browser, beginning test..");
+            switch (user.toUpperCase()) {
+                case "DCU":
+                    enterHocsLoginDetails(DCU);
+                    break;
+                case "TEST":
+                    enterHocsLoginDetails(TEST);
+                    break;
+                case "CASEY":
+                    enterHocsLoginDetails(CASEY);
+                    break;
+                case "EAMON":
+                    enterHocsLoginDetails(EAMON);
+                    break;
+                default:
+                    pendingStep(user + " is not defined within " + getMethodName());
+            }
+            clickOn(loginPage.continueButton);
+        } else {
+            System.out.println("Browser not closed down correctly, attempting to continue test");
+            dashboard.goToDashboard();
+        }
+    }
+
     @Given("^I am on the Home Office Correspondence Login Page")
     public void homeUrl() {
         navigateToHocs();

--- a/src/test/java/com/hocs/test/glue/LoginStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/LoginStepDefs.java
@@ -72,6 +72,42 @@ public class LoginStepDefs extends Page {
         }
     }
 
+    @Given("^I log in as the designated user$")
+    public void iLogInAsTheDesignatedUser() {
+        String user = System.getProperty("user");
+
+        if (user == null) {
+            System.out.println("User parameter not set. Defaulting to 'EAMON'");
+            user = "EAMON";
+        }
+
+        navigateToHocs();
+
+        if (isElementDisplayed($(loginPage.usernameField))) {
+            System.out.println("On fresh browser, beginning test..");
+            switch (user.toUpperCase()) {
+                case "DCU":
+                    enterHocsLoginDetails(DCU);
+                    break;
+                case "TEST":
+                    enterHocsLoginDetails(TEST);
+                    break;
+                case "CASEY":
+                    enterHocsLoginDetails(CASEY);
+                    break;
+                case "EAMON":
+                    enterHocsLoginDetails(EAMON);
+                    break;
+                default:
+                    pendingStep(user + " is not defined within " + getMethodName());
+            }
+            clickOn(loginPage.continueButton);
+        } else {
+            System.out.println("Browser not closed down correctly, attempting to continue test");
+            homepage.goHome();
+        }
+    }
+
     @Given("^that I have navigated to the Management UI as the user \"([^\"]*)\"$")
     public void iHaveNavigatedToTheManagementUI(String user) {
         navigateToManagementUI();

--- a/src/test/java/config/Passwords.java
+++ b/src/test/java/config/Passwords.java
@@ -6,7 +6,8 @@ public enum Passwords {
     DCUPASS("Password1"),
     TESTERPASS(""),
     EAMONPASS("Password1!"),
-    FAKEPASS("FAKE1!");
+    FAKEPASS("FAKE1!"),
+    PROD("");
 
     private final String password;
 

--- a/src/test/java/config/Usernames.java
+++ b/src/test/java/config/Usernames.java
@@ -6,7 +6,8 @@ public enum Usernames {
     DCUSER("smoke_test_user_dcu"),
     TESTER(""),
     EAMONDROKO("eamon.droko@ten10.com"),
-    FAKEUSER("FakeUser");
+    FAKEUSER("FakeUser"),
+    PROD("");
 
     private final String username;
 

--- a/src/test/java/config/Users.java
+++ b/src/test/java/config/Users.java
@@ -6,7 +6,8 @@ public enum Users {
     TEST("",""),
     CASEY("casey.prosser@ten10.com", "Password1!"),
     EAMON("eamon.droko@ten10.com", "Password1!"), //Just Eamon
-    FAKE("FakeUser", "FAKE1!");
+    FAKE("FakeUser", "FAKE1!"),
+    PROD("", "");
    /* NoTEAM("NoTEAM@placeholder.com", "Password1!"),
     // Initial Drafting Team Users
     PressOffice("eamon.droko+pressoffice@ten10.com", "Password1!"),

--- a/src/test/resources/features/CaseDetailsAccordion.feature
+++ b/src/test/resources/features/CaseDetailsAccordion.feature
@@ -1,7 +1,7 @@
 Feature: User can view correct case details at all stages
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
 
   @Accordion
   Scenario: Data Input accordion should contain the same information entered at the Case Creation stage

--- a/src/test/resources/features/CreateCase.feature
+++ b/src/test/resources/features/CreateCase.feature
@@ -1,7 +1,7 @@
 Feature: HOCS User is able to create a case
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
     When I am on the "CREATE SINGLE CASE" page
 
   @HOCS-341 @HOCS-491 @HOCS-236 @DCUMIN

--- a/src/test/resources/features/DataInput.feature
+++ b/src/test/resources/features/DataInput.feature
@@ -1,7 +1,7 @@
 Feature: HOCS User is able to add data to a case
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
     And I get a "DCU MIN" case at "DATA INPUT" stage
 
   @HOCS-274 @HOCS-238

--- a/src/test/resources/features/Dispatch.feature
+++ b/src/test/resources/features/Dispatch.feature
@@ -1,7 +1,7 @@
 Feature:  HOCS User is able to Dispatch a Response
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
     And I get a "DCU N10" case at "DISPATCH" stage
 
   @HOCS-542

--- a/src/test/resources/features/DraftResponse.feature
+++ b/src/test/resources/features/DraftResponse.feature
@@ -1,7 +1,7 @@
 Feature: HOCS User is able to draft a response
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
     And I get a "DCU MIN" case at "INITIAL DRAFT" stage
 
   @HOCS-287, @HOCS-239

--- a/src/test/resources/features/EndToEnd.feature
+++ b/src/test/resources/features/EndToEnd.feature
@@ -1,7 +1,7 @@
 Feature: HOCS is able to move cases through the entire flow
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
 
   @Workflow @SmokeTests
   Scenario Outline: Case moves to Data Input stage

--- a/src/test/resources/features/ManagementUI.feature
+++ b/src/test/resources/features/ManagementUI.feature
@@ -1,7 +1,7 @@
 Feature: User manages HOCS teams, topics and units
 
   Background:
-    Given that I have navigated to the Management UI as the user "EAMON"
+    Given that I have navigated to the Management UI as the designated user
 
   @ManagementUI
   Scenario Outline: User navigates to a management page

--- a/src/test/resources/features/MarkUp.feature
+++ b/src/test/resources/features/MarkUp.feature
@@ -1,7 +1,7 @@
 Feature: DCU user decides how a case should be handled
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
     When I get a "DCU N10" case at "MARKUP" stage
 
   @HOCS-266, @HOCS-237

--- a/src/test/resources/features/MinisterSignOff.feature
+++ b/src/test/resources/features/MinisterSignOff.feature
@@ -1,7 +1,7 @@
 Feature: User decides how cases should be handled at Minister Sign Off stage
-  
-  Background: 
-    Given I am user "EAMON"
+
+  Background:
+    Given I log in as the designated user
     When I get a "DCU MIN" case at "MINISTERIAL SIGN OFF" stage
 
   @Navigation

--- a/src/test/resources/features/POSignOff.feature
+++ b/src/test/resources/features/POSignOff.feature
@@ -1,7 +1,7 @@
 Feature: User decides how cases should be handled at Private Office Sign Off stage
 
-  Background: 
-    Given I am user "EAMON"
+  Background:
+    Given I log in as the designated user
     When I get a "DCU MIN" case at "PRIVATE OFFICE APPROVAL" stage
 
   @Navigation

--- a/src/test/resources/features/QACase.feature
+++ b/src/test/resources/features/QACase.feature
@@ -1,8 +1,8 @@
 Feature: QA Case #this test can be reused for both the private office and minister sign off stages
 
     Background:
-    Given I am user "EAMON"
-    And I get a "DCU N10" case at "QA RESPONSE" stage
+      Given I log in as the designated user
+      And I get a "DCU N10" case at "QA RESPONSE" stage
  
     @HOCS-310
     Scenario: User reviews draft, rejects it and provides a rejection reason

--- a/src/test/resources/features/RejectFlow.feature
+++ b/src/test/resources/features/RejectFlow.feature
@@ -1,7 +1,7 @@
 Feature: If the response is rejected the case is returned to certain stages in the flow
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
 
   @RejectFlow @QAResponse @Critical @Workflow @SmokeTests @DCUMIN
     Scenario: DCU MIN Case returned to Initial Draft stage when rejected by QA Response Team

--- a/src/test/resources/features/RemoveDocuments.feature
+++ b/src/test/resources/features/RemoveDocuments.feature
@@ -1,7 +1,7 @@
 Feature: A user can remove any documents attached to the case
 
   Scenario:  Document can be removed from the case
-    Given I am user "<string>"
+    Given I log in as the designated user
     And I am at the "Data Entry" stage
     And I am viewing a case with "one or more" documents attached
     When I remove a document from the case

--- a/src/test/resources/features/SearchForm.feature
+++ b/src/test/resources/features/SearchForm.feature
@@ -1,7 +1,7 @@
 Feature: Search should be available for all users of the application
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
 #    When I am on the "SEARCH" page
 
   @SearchForm @Validation

--- a/src/test/resources/features/SendCopyToNumber10.feature
+++ b/src/test/resources/features/SendCopyToNumber10.feature
@@ -1,7 +1,7 @@
 Feature: Send Copy to Number 10
 
   Background:
-    Given I am user "<string>"
+    Given I log in as the designated user
     And I am at the "QA" stage
 
   @HOCS-471

--- a/src/test/resources/features/StandardLine.feature
+++ b/src/test/resources/features/StandardLine.feature
@@ -1,7 +1,7 @@
 Feature: User is able to add Standard Lines
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
     When I navigate to the "ADD STANDARD LINE" page
 
 

--- a/src/test/resources/features/Topics.feature
+++ b/src/test/resources/features/Topics.feature
@@ -1,7 +1,7 @@
 Feature: HOCS Topics are assigned to the correct Team
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
 
   @Topics @TopicsDefaultTeams
   Scenario Outline: Topics are assigned to the correct team

--- a/src/test/resources/features/UploadDocuments.feature
+++ b/src/test/resources/features/UploadDocuments.feature
@@ -1,6 +1,6 @@
 Feature: A user can upload documents to a case #this test can be run at any stage
 
-  Given I am 'user'
+Given I log in as the designated user
   And I am working on 'stage'
   
   @HOCS-273, @HOCS-238

--- a/src/test/resources/features/Workstacks.feature
+++ b/src/test/resources/features/Workstacks.feature
@@ -1,7 +1,7 @@
 Feature: Team members can allocate work
 
   Background:
-    Given I am user "EAMON"
+    Given I log in as the designated user
 
   @Unallocate @DCUMIN
   Scenario: A single case is unallocated from the current user


### PR DESCRIPTION
Added methods so that user can be designated at cmd line. Defaults to EAMON if not passed in.
e.g.g add "-Duser=CASEY" to run cmd to execute all tests using CASEY credentials