### PR TITLE
Added some MUI Team Management methods that we had in WCS pack into t…

### DIFF
--- a/src/test/java/com/hocs/test/glue/decs/ManagementUIStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/ManagementUIStepDefs.java
@@ -134,23 +134,26 @@ public class ManagementUIStepDefs extends BasePage {
     public void addUserToSelectedTeam(String user) {
         waitABit(1000);
         teamManagement.assertTeamName();
-        teamManagement.selectAUser(User.valueOf(user));
-    }
-
-    @Then("{string} should be visible in the team list")
-    public void assertThatUserIsVisibleInTeamList(String user) {
-        teamManagement.assertThatUserIsVisibleInTeamList(User.valueOf(user));
+        teamManagement.addTeamMember(User.valueOf(user));
     }
 
     @And("I remove the user {string} from the team")
     public void removeUserFromTeamAndStoreUserName(String user) {
-        teamManagement.clearTeamMember(user);
-        setSessionVariable("removedUser").to(user);
+        teamManagement.removeTeamMember(User.valueOf(user));
     }
 
-    @Then("that user should no longer appear in the list of team members")
-    public void assertThatUserHasBeenRemovedFromTeam() {
-        teamManagement.assertThatRemovedUserIsNoLongerVisibleInList();
+    @Then("the user {string} be visible in the team list")
+    public void assertUserVisiblityInTeamList(String shouldShouldNot) {
+        switch (shouldShouldNot.toUpperCase()) {
+            case "SHOULD":
+                teamManagement.assertThatUserVisibleInTeamListIs(true);
+                break;
+            case "SHOULD NOT":
+                teamManagement.assertThatUserVisibleInTeamListIs(false);
+                break;
+            default:
+                pendingStep(shouldShouldNot + " is not defined within " + getMethodName());
+        }
     }
 
     @When("I search for a team with no assigned users")

--- a/src/test/resources/features/cs/ManagementUI.feature
+++ b/src/test/resources/features/cs/ManagementUI.feature
@@ -24,11 +24,13 @@ Feature: ManagementUI
     Then no users should be shown in user list
 
   @TeamManagement @CSRegression
-  Scenario: Adding a new user to a team displays that user in the team list
+  Scenario: Users can be added and removed from teams in CS Management UI
     And I navigate to the "TEAM" Management page
     When I select the "UK Central Authority" team from the dropdown
-    And I add the user "CAMERON" to the team
-    Then "CAMERON" should be visible in the team list
+    And I add the user "TEST_USER_1" to the team
+    Then the user "should" be visible in the team list
+    When I remove the user "TEST_USER_1" from the team
+    Then the user "should not" be visible in the team list
 
   @TeamManagement
   Scenario: User can add multiple users to a team
@@ -36,13 +38,6 @@ Feature: ManagementUI
     When I select the "Animals in Science Regulation Unit" team from the dropdown
     And I add the users "CAMERON" and "CASEY" to the team
     Then the users should be visible in the team list
-
-  @TeamManagement @CSRegression
-  Scenario: Users should no longer be visible in team page when removed
-    And I navigate to the "TEAM" Management page
-    When I select the "UK Central Authority" team from the dropdown
-    And I remove the user "CAMERON" from the team
-    Then that user should no longer appear in the list of team members
 
   @TeamManagement @Validation
   Scenario: User should see an error when attempting to remove user from team that they currently have assigned cases in
@@ -346,7 +341,7 @@ Feature: ManagementUI
     And I load the "renamed" DCU Drafting team through team management
     Then the "renamed" DCU Drafting team is displayed
 
-  @TeamManagement
+  @TeamManagement @CSRegression
   Scenario: User is able to assign users to a DCU drafting team created through team management
     Given I navigate to the "Create DCU Drafting Team" Management page
     And I create a new DCU drafting team
@@ -354,7 +349,7 @@ Feature: ManagementUI
     And I navigate to the "Team" Management page
     And I load the "created" DCU Drafting team through team management
     And I add the user "DCU_USER" to the team
-    Then "DCU_USER" should be visible in the team list
+    Then the user "should" be visible in the team list
 
   @TeamManagement
   Scenario: User is able to assign cases to a DCU drafting team created through team management

--- a/src/test/resources/features/wcs/WCSManagementUI.feature
+++ b/src/test/resources/features/wcs/WCSManagementUI.feature
@@ -8,17 +8,17 @@ Feature: Management UI
     Then I should be taken to the "TEAM" Management page
 
   @TeamManagement @WCSRegression
-  Scenario: Users can be added and removed from teams in Management UI
+  Scenario: Users can be added and removed from teams in WCS Management UI
     Given I am logged into "WCS Management UI" as user "WCS_USER"
     And I navigate to the "TEAM" Management page
     When I select the "Initial Consideration Casework" team from the dropdown
     And I add the user "TEST_USER_1" to the team
-    Then the users should be visible in the team list
+    Then the user "should" be visible in the team list
     When I remove the user "TEST_USER_1" from the team
-    Then that user should no longer appear in the list of team members
+    Then the user "should not" be visible in the team list
 
   @Validation
-  Scenario: User should see an error when attempting to remove user from team that they currently have assigned cases in
+  Scenario: User should see an error when attempting to remove user from a team that they currently have assigned cases in
     Given I am logged into "WCS Management UI" as user "WCS_USER"
     And I navigate to the "TEAM" Management page
     When I select the "WCS Registration Team" team from the dropdown


### PR DESCRIPTION
…his pack. They were the more succinct version, and the WCS MUI 'add / remove team members' was failing without them.

Amended the CS MUI 'add / remove team members' scenarios to have the same structure as the WCS version.