### PR TITLE
Created scenario 'As a Correspondence System user, when I add a docum…

### DIFF
--- a/src/test/java/com/hocs/test/glue/decs/CreateCaseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/CreateCaseStepDefs.java
@@ -225,9 +225,9 @@ public class CreateCaseStepDefs extends BasePage {
         createCase.assertDateReceivedIsInvalidErrorMessage();
     }
 
-    @When("I select {string} case type and continue")
-    public void getToWhenWasCorrespondenceReceivedPage(String caseType) {
-        createCase.selectCaseType(caseType);
+    @When("I select a case type and continue")
+    public void getToWhenWasCorrespondenceReceivedPage() {
+        createCase.selectCaseType("CS");
         safeClickOn(nextButton);
         waitABit(100);
     }

--- a/src/test/java/com/hocs/test/glue/decs/DocumentsStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/DocumentsStepDefs.java
@@ -21,7 +21,14 @@ public class DocumentsStepDefs extends BasePage {
 
     @And("I click to manage the documents of a new {string} case")
     public void iClickToManageTheDocumentsOfANewCase(String caseType) {
-        createCase.createCaseOfTypeWithoutDocument(caseType);
+        createCase.createCSCaseOfTypeWithoutDocument(caseType);
+        createCaseSuccessPage.goToCaseFromSuccessfulCreationScreen();
+        safeClickOn(documents.manageDocumentsLink);
+    }
+
+    @And("I manage the documents of a new case")
+    public void iManageTheDocumentsOfANewCase() {
+        createCase.createCSCaseOfTypeWithoutDocument("CS");
         createCaseSuccessPage.goToCaseFromSuccessfulCreationScreen();
         safeClickOn(documents.manageDocumentsLink);
     }
@@ -140,8 +147,9 @@ public class DocumentsStepDefs extends BasePage {
         iCanSeeTheFileInTheUploadedDocumentList(fileIdentifier);
     }
 
-    @And("I select to remove the {string} document")
+    @And("I remove the {string} document")
     public void iClickTheRemoveLinkForTheFile(String fileIdentifier) {
+        safeClickOn(documents.manageDocumentsLink);
         documents.clickRemoveLinkForFile(fileIdentifier);
         documents.clickRemoveButton();
     }
@@ -160,5 +168,23 @@ public class DocumentsStepDefs extends BasePage {
     @Then("the primary draft tag is next to the primary draft document")
     public void primaryDraftTagNextToPrimaryDraftDocument() {
         documents.assertVisibilityOfPrimaryDraftDocumentTag();
+    }
+
+    @And("I select a document type")
+    public void iSelectADocumentType() {
+        documents.selectADocumentType();
+    }
+
+    @And("I upload a file that fails to convert to PDF")
+    public void iUploadAFileThatWillFailToConvertToPDF() {
+        safeClickOn(documents.addDocumentLink);
+        documents.selectADocumentType();
+        documents.uploadDocumentThatFailsConversion();
+        clickTheButton("Add");
+    }
+
+    @Then("document should have the Failed Conversion tag")
+    public void documentShouldHaveTheFailedConversionTag() {
+        documents.assertFailedConversionTagVisible();
     }
 }

--- a/src/test/java/com/hocs/test/glue/decs/LoginStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/LoginStepDefs.java
@@ -202,7 +202,7 @@ public class LoginStepDefs extends BasePage {
             dashboard.selectMyCases();
             if (workstacks.getTotalOfCases() == 0) {
                 if (currentPlatform.equals("CS")){
-                createCase.createCSCaseOfType("ANY");
+                createCase.createCSCaseOfType("CS");
                 dashboard.getAndClaimCurrentCase();
                 }
                 else if (currentPlatform.equals("WCS")) {

--- a/src/test/java/com/hocs/test/pages/decs/CreateCase.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase.java
@@ -115,38 +115,33 @@ public class CreateCase extends BasePage {
     public void clickCreateCasesButton() {safeClickOn(createCasesButton);}
 
     public void selectCaseType(String caseType) {
-        if (caseType.equalsIgnoreCase("ANY")) {
-            caseType = getRandomCaseType();
-        }
-        switch (caseType.toUpperCase()) {
-            case "MIN":
-                clickDcuMinRadioButton();
-                break;
-            case "TRO":
-                clickDcuTroRadioButton();
-                break;
-            case "DTEN":
-                clickDcuDtenRadioButton();
-                break;
-            case "MPAM":
-                clickMpamRadioButton();
-                break;
-            case "MTS":
-                clickMtsRadioButton();
-                break;
-            case "COMP":
-                clickCompRadioButton();
-                break;
-            default:
-                pendingStep(caseType + " is not defined within " + getMethodName());
+        if (caseType.equalsIgnoreCase("CS")) {
+            caseType = selectRandomRadioButtonFromGroupWithHeading("What type of correspondence do you have?");
+        } else {
+            switch (caseType.toUpperCase()) {
+                case "MIN":
+                    clickDcuMinRadioButton();
+                    break;
+                case "TRO":
+                    clickDcuTroRadioButton();
+                    break;
+                case "DTEN":
+                    clickDcuDtenRadioButton();
+                    break;
+                case "MPAM":
+                    clickMpamRadioButton();
+                    break;
+                case "MTS":
+                    clickMtsRadioButton();
+                    break;
+                case "COMP":
+                    clickCompRadioButton();
+                    break;
+                default:
+                    pendingStep(caseType + " is not defined within " + getMethodName());
+            }
         }
         setSessionVariable("caseType").to(caseType);
-    }
-
-    public String getRandomCaseType() {
-        List<String> caseTypes = Arrays.asList("MIN", "DTEN", "TRO", "MPAM", "MTS", "COMP");
-        Random rand = new Random();
-        return caseTypes.get(rand.nextInt(caseTypes.size()));
     }
 
     // Multi Step Methods
@@ -164,8 +159,11 @@ public class CreateCase extends BasePage {
         createCaseSuccessPage.storeCaseReference();
     }
 
-    public void createCaseOfTypeWithoutDocument(String caseType) {
+    public void createCSCaseOfTypeWithoutDocument(String caseType) {
         dashboard.selectCreateSingleCaseLinkFromMenuBar();
+        if (!nextButton.isVisible()) {
+            dashboard.selectCreateSingleCaseLinkFromMenuBar();
+        }
         selectCaseType(caseType);
         safeClickOn(nextButton);
         clickCreateCaseButton();

--- a/src/test/java/com/hocs/test/pages/decs/Documents.java
+++ b/src/test/java/com/hocs/test/pages/decs/Documents.java
@@ -51,6 +51,9 @@ public class Documents extends BasePage {
     @FindBy(xpath = "//td/strong[contains(text(), 'PENDING')]")
     public WebElementFacade pendingTag;
 
+    @FindBy(xpath = "//td/strong[contains(text(), 'FAILED_CONVERSION')]")
+    public WebElementFacade failedConversionTag;
+
     @FindBy(xpath = "//td/strong[contains(text(), 'UPLOADED')]")
     public WebElementFacade uploadedTag;
 
@@ -93,6 +96,12 @@ public class Documents extends BasePage {
         addDocument.withTimeoutOf(Duration.ofSeconds(10)).waitUntilPresent();
         upload(System.getProperty("user.dir") + File.separator + "src" + File.separator + "test" +  File.separator + "resources" +  File.separator +
                 "documents" +  File.separator + "test."  + type).to(addDocument);
+    }
+
+    public void uploadDocumentThatFailsConversion() {
+        addDocument.withTimeoutOf(Duration.ofSeconds(10)).waitUntilPresent();
+        upload(System.getProperty("user.dir") + File.separator + "src" + File.separator + "test" +  File.separator + "resources" +  File.separator +
+                "documents" +  File.separator + "broken.jpg").to(addDocument);
     }
 
 
@@ -236,6 +245,10 @@ public class Documents extends BasePage {
         }
     }
 
+    public void assertFailedConversionTagVisible() {
+        failedConversionTag.withTimeoutOf(Duration.ofSeconds(60)).waitUntilVisible();
+    }
+
     public void waitForFileToUpload(Object fileIdentifier) {
         WebElementFacade documentUploadedTag =
                 findBy("//td[contains(text(), '" + fileIdentifier + "')]/following-sibling::td/a[@download]");
@@ -249,4 +262,5 @@ public class Documents extends BasePage {
     public void assertVisibilityOfPrimaryDraftDocumentTag() {
         assertThat(primaryDraftDocumentTag.isVisible(), is(true));
     }
+
 }

--- a/src/test/resources/features/cs/CreateCase.feature
+++ b/src/test/resources/features/cs/CreateCase.feature
@@ -26,7 +26,7 @@ Feature: Create case
 
   @Allocation
   Scenario: A single case is allocated to the current user
-    And I create a single "ANY" case
+    And I create a single "CS" case
     When I allocate the case to myself via the successful case creation screen
     And I click to view the "Summary" tab
     Then the case "Should" be allocated to me in the summary
@@ -34,7 +34,7 @@ Feature: Create case
 
   @Allocation
   Scenario: A single case is allocated to another user
-    And I create a single "ANY" case
+    And I create a single "CS" case
     And I go to the case from the successful case creation screen
     When I allocate the case to another user on the case details accordion screen
     And I load the current case
@@ -71,14 +71,14 @@ Feature: Create case
 
   @Validation
   Scenario: When creating a single case the date received is required
-    And I select "Any" case type and continue
+    And I select a case type and continue
     And I enter a blank date
     And I click the "Create case" button
     Then an error message should be displayed as I have not entered the correspondence received date
 
   @Validation
   Scenario: When creating a Single MIN case a valid date must be entered
-    And I select "Any" case type and continue
+    And I select a case type and continue
     And I enter an invalid date
     And I click the "Create case" button
     Then an error message should be displayed as I have entered an invalid date

--- a/src/test/resources/features/cs/ManageDocuments.feature
+++ b/src/test/resources/features/cs/ManageDocuments.feature
@@ -5,13 +5,13 @@ Feature: Manage Documents
     Given I am logged into "CS" as user "DECS_USER"
 
   @CSRegression
-  Scenario Outline: User can upload, preview and remove a file of any allowed file type
-    And I click to manage the documents of a new "MPAM" case
+  Scenario Outline: As a Correspondence System user, I want to be able to upload to, preview, and remove from, a case any document that is of an
+  allowed filetype, so I can complete my work
+    And I manage the documents of a new case
     And I add a "<fileType>" document to the case
     Then I can see the "<fileType>" file in the uploaded document list
     And the "<fileType>" document should be selected to be displayed in the preview pane
-    When I click manage documents
-    And I select to remove the "<fileType>" document
+    When I remove the "<fileType>" document
     Then I cannot see the "<fileType>" file in the uploaded document list
     Examples:
       | fileType |
@@ -28,7 +28,7 @@ Feature: Manage Documents
       | doc      |
 
   @DCURegression
-  Scenario Outline: User can select document type when uploading documents on a DCU case
+  Scenario Outline: As a DCU user, I want to be able to select the type of an uploaded document, so the document can be easily identified later
     And I click to manage the documents of a new "MIN" case
     And I click add documents
     When I choose the document type "<docType>"
@@ -43,7 +43,7 @@ Feature: Manage Documents
       | BACKGROUND NOTE |
 
   @UKVIRegression2
-  Scenario Outline: User can select document type when uploading documents on a MPAM case
+  Scenario Outline: As a MPAM user, I want to be able to select the type of an uploaded document, so the document can be easily identified later
     And I click to manage the documents of a new "MPAM" case
     And I click add documents
     When I choose the document type "<docType>"
@@ -61,68 +61,54 @@ Feature: Manage Documents
       | Additional correspondence (Holding Replies) |
 
   @Validation
-  Scenario: User must select a document type when uploading a document
-    And I click to manage the documents of a new "MIN" case
+  Scenario: As a Correspondence System user, I want to be informed when I fail to select a document type, so I can rectify the mistake
+    And I manage the documents of a new case
     And I click add documents
     When I upload a file of type "docx"
     Then an error message should be displayed as I have not selected a document type
 
   @Validation
-  Scenario: User must select a file when uploading a document
-    And I click to manage the documents of a new "MIN" case
+  Scenario: As a Correspondence System user, I want to be informed when I fail to select a file to upload, so I can rectify the mistake
+    And I manage the documents of a new case
     And I click add documents
-    When I choose the document type "Draft"
+    When I select a document type
     And I click the "Add" button
     Then an error message should be displayed as I have not selected a file to upload
 
 
   @Validation
-  Scenario: User cannot upload a document that has a file type that is not on the whitelist
-    And I click to manage the documents of a new "MIN" case
+  Scenario: As a Correspondence System user, I want to be informed when I attempt to upload a file of unsupported filetype, so I can rectify the mistake
+    And I manage the documents of a new case
     And I click add documents
-    When I choose the document type "Draft"
+    When I select a document type
     And I upload a file of type "csv"
     Then an error message should be displayed as I have selected a file type which is not allowed
     And I cannot see the "csv" file in the uploaded document list
 
 
-  Scenario: A document has the pending tag whilst it is being converted
-    And I click to manage the documents of a new "MIN" case
+  Scenario: As a Correspondence System user, I want to be able to tell when a document is still pending conversion, so I am informed about its status
+    And I manage the documents of a new case
     And I click add documents
-    When I choose the document type "Draft"
+    When I select a document type
     And I upload a file that is 5MB in size
     Then the document should have the Pending tag
 
   @CSRegression
-  Scenario: User can select which document to preview
-    And I click to manage the documents of a new "MIN" case
+  Scenario: As a Correspondence System user, when I add a document that fails to convert to PDF, I want to be informed of the failure
+    And I manage the documents of a new case
+    When I upload a file that fails to convert to PDF
+    Then document should have the Failed Conversion tag
+
+  @CSRegression
+  Scenario: As a Correspondence System user, I want to be able to select which document to preview, so I can inspect different uploaded documents
+    And I manage the documents of a new case
     And I upload a 5MB and a 10MB file
     And the "5MB" document should be selected to be displayed in the preview pane
     And I click the preview button of the "10MB" file
     Then the "10MB" document should be selected to be displayed in the preview pane
 
-  Scenario Outline: User can remove any document
-    And I click to manage the documents of a new "MPAM" case
-    And I add a "<fileType>" document to the case
-    And I click manage documents
-    And I select to remove the "<fileType>" document
-    Then I cannot see the "<fileType>" file in the uploaded document list
-    Examples:
-      | fileType |
-      | docx     |
-      | txt      |
-      | pdf      |
-      | tiff     |
-      | xlsx     |
-      | gif      |
-      | html     |
-      | jpg      |
-      | png      |
-      | bmp      |
-      | doc      |
-
   @DCURegression
-  Scenario: User checks that the primary draft tag is visible after the initial draft stage
+  Scenario: As a DCU user, I want to be able to see a Primary Draft tag next to a document, so I know it is the Primary Draft
     And I create a "MIN" case and move it to the "QA Response" stage
     And I load and claim the current case
     Then the primary draft tag is next to the primary draft document

--- a/src/test/resources/features/wcs/WCSManageDocuments.feature
+++ b/src/test/resources/features/wcs/WCSManageDocuments.feature
@@ -49,8 +49,7 @@ Feature: WCS Manage Documents
   @WCSRegression
   Scenario: User can remove a document
     And I add a "docx" document to the claim
-    And I click manage documents
-    And I select to remove the "docx" document
+    When I remove the "docx" document
     Then I cannot see the "docx" file in the uploaded document list
 
   @Validation
@@ -82,8 +81,7 @@ Feature: WCS Manage Documents
 
   Scenario Outline: User can remove any document
     And I add a "<fileType>" document to the claim
-    And I click manage documents
-    And I select to remove the "<fileType>" document
+    When I remove the "<fileType>" document
     Then I cannot see the "<fileType>" file in the uploaded document list
     Examples:
       | fileType |


### PR DESCRIPTION
…ent that fails to convert to PDF, I want to be informed of the failure', to cover ticket HOCS-3508

Reworked some documents steps and methods, so that more CS scenarios could be workflow agnostic, giving us greater test coverage/scope.
Combined some steps in ManageDocuments feature, so BDD scenarios are written at higher level.
Reworded scenario titles in ManageDocuments feature to use "As a 'x' User, I want 'x', So that 'x'" structure.