### PR TITLE
Added correct values into search step for search by case reference sc…

### DIFF
--- a/src/test/java/com/hocs/test/glue/decs/SearchStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/SearchStepDefs.java
@@ -157,7 +157,7 @@ public class SearchStepDefs extends BasePage {
         safeClickOn(searchButton);
     }
 
-    @And("the created case should be visible in the search results")
+    @And("the created case should be the only case visible in the search results")
     public void createdCaseShouldBeVisibleInTheSearchResults(){
         workstacks.filterByCurrentCaseReference();
         waitABit(1000);
@@ -167,7 +167,7 @@ public class SearchStepDefs extends BasePage {
             if (numberOfResults < 1) {
                 retest ++;
                 dashboard.selectSearchLinkFromMenuBar();
-                searchForMPAMCaseWith(sessionVariableCalled("infoType"), sessionVariableCalled("infoValue"));
+                searchForMPAMCaseWith(getCurrentCaseReference(), "Case Reference");
                 safeClickOn(searchButton);
                 workstacks.filterByCurrentCaseReference();
                 waitABit(1000);

--- a/src/test/java/com/hocs/test/glue/decs/WorkstacksStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/WorkstacksStepDefs.java
@@ -68,12 +68,12 @@ public class WorkstacksStepDefs extends BasePage {
 
     @When("I enter the Case Reference type {string} into the filter")
     public void enterCaseReferenceType(String caseReferenceType) {
-        safeClickOn(workstacks.workstackFilter);
+        safeClickOn(workstacks.caseFilter);
         switch (caseReferenceType.toUpperCase()) {
             case "MIN":
             case "DTEN":
             case "TRO":
-                workstacks.workstackFilter.sendKeys(caseReferenceType);
+                workstacks.caseFilter.sendKeys(caseReferenceType);
                 break;
             default:
                 pendingStep(caseReferenceType + " is not defined within " + getMethodName());
@@ -110,8 +110,8 @@ public class WorkstacksStepDefs extends BasePage {
 
     @When("I enter the current stage {string} into the filter")
     public void enterCurrentStage(String currentStage) {
-        safeClickOn(workstacks.workstackFilter);
-        workstacks.workstackFilter.sendKeys(currentStage.toUpperCase());
+        safeClickOn(workstacks.caseFilter);
+        workstacks.caseFilter.sendKeys(currentStage.toUpperCase());
     }
 
     @Then("all cases should be allocated to the user {string}")

--- a/src/test/java/com/hocs/test/pages/decs/Dashboard.java
+++ b/src/test/java/com/hocs/test/pages/decs/Dashboard.java
@@ -207,13 +207,14 @@ public class Dashboard extends BasePage {
 
     public void claimCurrentCase() {
         int attempts = 0;
-        while (attempts < 3 && !unallocatedCaseView.caseCanBeAllocated()) {
+        while (attempts < 6 && !unallocatedCaseView.caseCanBeAllocated()) {
             waitABit(5000);
             setCaseReferenceFromUnassignedCase();
             goToDashboard();
             getCurrentCase();
             attempts++;
         }
+        assertThat(unallocatedCaseView.caseCanBeAllocated(), is(true));
         unallocatedCaseView.clickAllocateToMeLink();
     }
 

--- a/src/test/java/com/hocs/test/pages/decs/Workstacks.java
+++ b/src/test/java/com/hocs/test/pages/decs/Workstacks.java
@@ -36,7 +36,7 @@ public class Workstacks extends BasePage {
     public WebElementFacade unallocateButton;
 
     @FindBy(id = "workstack-filter")
-    public WebElementFacade workstackFilter;
+    public WebElementFacade caseFilter;
 
     @FindBy(css = "[value = 'Allocate']")
     public WebElementFacade allocateButton;
@@ -225,8 +225,8 @@ public class Workstacks extends BasePage {
     }
 
     public void refineWorkstackSearchResults(String workstackInput) {
-        safeClickOn(workstackFilter);
-        workstackFilter.sendKeys(workstackInput);
+        safeClickOn(caseFilter);
+        caseFilter.sendKeys(workstackInput);
     }
 
     public void recordHighestPriorityCases() {
@@ -310,7 +310,7 @@ public class Workstacks extends BasePage {
     }
 
     public void waitForWorkstackToLoad() {
-        allocateSelectedToMeButton.withTimeoutOf(Duration.ofSeconds(30)).waitUntilVisible();
+        caseFilter.withTimeoutOf(Duration.ofSeconds(60)).waitUntilVisible();
     }
 
     public void orderMPAMWorkstackColumn(String column, String order) {
@@ -384,7 +384,7 @@ public class Workstacks extends BasePage {
     }
 
     public void unallocateSelectedCase(String caseRef) {
-        workstackFilter.sendKeys(caseRef);
+        caseFilter.sendKeys(caseRef);
         waitABit(500);
         WebElementFacade selectedCaseCheckBox = findBy("//a[text()='" + caseRef + "']/parent::td/preceding-sibling::td//label");
         safeClickOn(selectedCaseCheckBox);
@@ -478,7 +478,7 @@ public class Workstacks extends BasePage {
     }
 
     private String getStageFromWorkstacksTable() {
-        workstackFilter.withTimeoutOf(Duration.ofSeconds(30)).waitUntilVisible();
+        caseFilter.withTimeoutOf(Duration.ofSeconds(30)).waitUntilVisible();
         WebElement caseReferenceStage = getDriver().findElement(
                 By.xpath("//a[text()='" + getCurrentCaseReference()
                         + "']/../following-sibling::td[1]"));
@@ -498,7 +498,7 @@ public class Workstacks extends BasePage {
     }
 
     public void filterByCurrentCaseReference() {
-        workstackFilter.sendKeys(getCurrentCaseReference());
+        caseFilter.sendKeys(getCurrentCaseReference());
     }
 
     public void assertAssignedUser(User user) {
@@ -541,7 +541,7 @@ public class Workstacks extends BasePage {
         refineWorkstackSearchResults(caseType);
         waitABit(1000);
         int totalCases = getTotalOfCases();
-        workstackFilter.clear();
+        caseFilter.clear();
         return (totalCases != 0);
     }
 
@@ -709,7 +709,7 @@ public class Workstacks extends BasePage {
     }
 
     public void assertHigherPriorityCaseIsFirstInWorkstack(String highPriorityCase, String lowPriorityCase) {
-        workstackFilter.withTimeoutOf(Duration.ofSeconds(10)).waitUntilVisible();
+        caseFilter.withTimeoutOf(Duration.ofSeconds(10)).waitUntilVisible();
         String highPriorityReference = sessionVariableCalled(highPriorityCase);
         String lowPriorityReference = sessionVariableCalled(lowPriorityCase);
 
@@ -740,7 +740,7 @@ public class Workstacks extends BasePage {
     }
 
     public void assertDueDateOfContributionRequest() {
-        workstackFilter.withTimeoutOf(Duration.ofSeconds(60)).waitUntilVisible();
+        caseFilter.withTimeoutOf(Duration.ofSeconds(60)).waitUntilVisible();
         String caseRef = getCurrentCaseReference();
         WebElementFacade caseWithDueDate = findBy("//a[text()='" + caseRef + "']/parent::td/following-sibling::td[contains(text(), '(Contribution "
                 + "Requested) due:')]");
@@ -756,7 +756,7 @@ public class Workstacks extends BasePage {
     }
 
     private List<String> getTableHeadersContent() {
-        waitFor(workstackFilter);
+        waitFor(caseFilter);
         List<WebElement> tableHeaders = getDriver().findElements(By.cssSelector(("th[class*='govuk-table__header']")));
         List<String> tableHeadersContent = new ArrayList<>();
         for (WebElement tableHeader : tableHeaders) {

--- a/src/test/resources/features/comp/COMPSearch.feature
+++ b/src/test/resources/features/comp/COMPSearch.feature
@@ -26,7 +26,7 @@ Feature: COMP Search
   Scenario: User can search for a COMP case by its case reference
     When I create a single "COMP" case
     And I search for the case by its case reference
-    Then the created case should be visible in the search results
+    Then the created case should be the only case visible in the search results
 
 #     HOCS-2847 HOCS-3161
   @COMPRegression

--- a/src/test/resources/features/ukvi2/UKVISearch.feature
+++ b/src/test/resources/features/ukvi2/UKVISearch.feature
@@ -27,7 +27,7 @@ Feature: UKVI Search
     And I create a MPAM case with "UKVI" as the Business Area and "Ministerial" as the Reference Type and move it to the "Triage" stage
     And I navigate to the "Search" page
     And I search for a case by it's case reference
-    Then the created case should be visible in the search results
+    Then the created case should be the only case visible in the search results
 
   @UKVIRegression2
   Scenario: User searches for MPAM cases using a substring of a case reference


### PR DESCRIPTION
…enarios, and reworded to be clearer what it acheives.

Amended workstackFilter name to caseFilter to better reflect DECS terminology.
Changed waitForWorkstack method to use caseFilter instead of allocateToMe button, as not all workstacks have the button.
Increased number of times a case is reloaded if it doesnt yet have the allocation options visible after just moving stages, but added assertion after while block so subsequent check doesnt take 60 seconds and can fail sooner.