### PR TITLE
Renamed UnallocatedCaseVie to CaseView, as it has elements that are v…

### DIFF
--- a/src/test/java/com/hocs/test/glue/comp/COMPSendStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/comp/COMPSendStepDefs.java
@@ -8,8 +8,15 @@ public class COMPSendStepDefs extends BasePage {
 
     COMPSend compSend;
 
-    @And("I select a Case Outcome at the {string} Send stage")
-    public void iSelectACaseOutcomeAtTheServiceSendStage(String complaintType) {
-        compSend.submitASelectedOutcome();
+    @And("I select a Case Outcome")
+    public void iSelectACaseOutcome() {
+        compSend.selectACaseOutcome();
+    }
+
+    @And("I submit the Response details")
+    public void iEnterTheRepsonseDetails() {
+        compSend.selectAResponseChannel();
+        compSend.enterADateOfResponse();
+        clickTheButton("Complete");
     }
 }

--- a/src/test/java/com/hocs/test/glue/comp/COMPTriageStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/comp/COMPTriageStepDefs.java
@@ -73,4 +73,16 @@ public class COMPTriageStepDefs extends BasePage {
     public void highlightingCheckAtServiceTriage() {
         compTriage.assertOverdueContributionRequestIsHighlighted();
     }
+
+    @And("I accept the previous Claim Category selection")
+    public void iAcceptThePreviousClaimCatagorySelection() {
+        waitForPageWithTitle("Complaint Category");
+        clickTheButton("Continue");
+    }
+
+    @And("I accept the previous Severity selection")
+    public void iAcceptThePreviousSeveritySelection() {
+        waitForPageWithTitle("Triage Case Details");
+        clickTheButton("Continue");
+    }
 }

--- a/src/test/java/com/hocs/test/glue/dcu/DCUCaseDetailsAccordionStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/DCUCaseDetailsAccordionStepDefs.java
@@ -5,7 +5,7 @@ import static net.serenitybdd.core.Serenity.pendingStep;
 
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.Workstacks;
 import com.hocs.test.pages.dcu.AccordionDCU;
 import com.hocs.test.pages.dcu.DataInput;
@@ -40,7 +40,7 @@ public class DCUCaseDetailsAccordionStepDefs extends BasePage {
 
     Dispatch dispatch;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
 
     @When("I move that case to the {string} stage and record all entered information")
@@ -52,37 +52,37 @@ public class DCUCaseDetailsAccordionStepDefs extends BasePage {
             case "Initial Draft":
                 moveCaseToNextStage("Markup");
                 dashboard.getCurrentCase();
-                safeClickOn(unallocatedCaseView.allocateToMeLink);
+                safeClickOn(caseView.allocateToMeLink);
                 markup.completeMarkupStageAndStoreEnteredInformation();
                 break;
             case "QA Response":
                 moveCaseToNextStage("Initial Draft");
                 dashboard.getCurrentCase();
-                safeClickOn(unallocatedCaseView.allocateToMeLink);
+                safeClickOn(caseView.allocateToMeLink);
                 initialDraft.completeInitialDraftStageAndStoreEnteredInformation();
                 break;
             case "Private Office Approval":
                 moveCaseToNextStage("QA Response");
                 dashboard.getCurrentCase();
-                safeClickOn(unallocatedCaseView.allocateToMeLink);
+                safeClickOn(caseView.allocateToMeLink);
                 qaResponse.completeQAResponseStageAndStoreEnteredInformation();
                 break;
             case "Ministerial Sign Off":
                 moveCaseToNextStage("Private Office Approval");
                 dashboard.getCurrentCase();
-                safeClickOn(unallocatedCaseView.allocateToMeLink);
+                safeClickOn(caseView.allocateToMeLink);
                 privateOfficeApproval.completePrivateOfficeApprovalStageAndStoreEnteredInformation();
                 break;
             case "Dispatch":
                 moveCaseToNextStage("Ministerial Sign Off");
                 dashboard.getCurrentCase();
-                safeClickOn(unallocatedCaseView.allocateToMeLink);
+                safeClickOn(caseView.allocateToMeLink);
                 ministerialSignOff.completeMinisterialSignOffStageAndStoreEnteredInformation();
                 break;
             case "Transfer to No10":
                 moveCaseToNextStage("Dispatch");
                 dashboard.getCurrentCase();
-                safeClickOn(unallocatedCaseView.allocateToMeLink);
+                safeClickOn(caseView.allocateToMeLink);
                 dispatch.completeDispatchStageAndStoreEnteredInformation();
                 break;
             default:

--- a/src/test/java/com/hocs/test/glue/dcu/DataInputStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/DataInputStepDefs.java
@@ -9,7 +9,7 @@ import com.hocs.test.pages.decs.AddCorrespondent;
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.SummaryTab;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.dcu.AccordionDCU;
 import com.hocs.test.pages.dcu.DataInput;
 import io.cucumber.java.en.And;
@@ -24,7 +24,7 @@ public class DataInputStepDefs extends BasePage {
 
     Dashboard dashboard;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     AccordionDCU accordionDCU;
 
@@ -39,7 +39,7 @@ public class DataInputStepDefs extends BasePage {
     public void completeDataInputPerCaseType() {
         if (!dataInput.continueButton.isVisible()) {
             dashboard.getCurrentCase();
-            safeClickOn(unallocatedCaseView.allocateToMeLink);
+            safeClickOn(caseView.allocateToMeLink);
         }
         dataInput.moveCaseFromDataInputToMarkup();
     }

--- a/src/test/java/com/hocs/test/glue/dcu/DispatchStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/DispatchStepDefs.java
@@ -2,7 +2,7 @@ package com.hocs.test.glue.dcu;
 
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.dcu.Dispatch;
 import io.cucumber.java.en.When;
 import net.thucydides.core.annotations.Managed;
@@ -15,13 +15,13 @@ public class DispatchStepDefs extends BasePage {
 
     Dashboard dashboard;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     @When("I complete the dispatch stage")
     public void completeTheDispatchStage() {
         if (!dispatch.dispatchAcceptRadioButton.isVisible()) {
             dashboard.getCurrentCase();
-            safeClickOn(unallocatedCaseView.allocateToMeLink);
+            safeClickOn(caseView.allocateToMeLink);
         }
         safeClickOn(dispatch.dispatchAcceptRadioButton);
         safeClickOn(continueButton);

--- a/src/test/java/com/hocs/test/glue/dcu/InitialDraftStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/InitialDraftStepDefs.java
@@ -8,7 +8,7 @@ import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.Documents;
 import com.hocs.test.pages.decs.SummaryTab;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.Workstacks;
 import com.hocs.test.pages.dcu.InitialDraft;
 import config.User;
@@ -26,7 +26,7 @@ public class InitialDraftStepDefs extends BasePage {
 
     Workstacks workstacks;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     SummaryTab summaryTab;
 
@@ -34,7 +34,7 @@ public class InitialDraftStepDefs extends BasePage {
     public void initialDraftFullFlowPerCaseType() {
         if (!initialDraft.answeredByMyTeamYesRadioButton.isVisible()) {
             dashboard.getCurrentCase();
-            safeClickOn(unallocatedCaseView.allocateToMeLink);
+            safeClickOn(caseView.allocateToMeLink);
         }
         String caseType = sessionVariableCalled("caseType");
         switch (caseType.toUpperCase()) {

--- a/src/test/java/com/hocs/test/glue/dcu/MarkupStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/MarkupStepDefs.java
@@ -7,7 +7,7 @@ import static net.serenitybdd.core.Serenity.setSessionVariable;
 
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.Workstacks;
 import com.hocs.test.pages.dcu.InitialDraft;
 import com.hocs.test.pages.dcu.Markup;
@@ -31,13 +31,13 @@ public class MarkupStepDefs extends BasePage {
 
     QAResponse qaResponse;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     @When("I complete the Markup stage")
     public void completeTheMarkupStage() {
         if (!markup.policyResponseRadioButton.isVisible()) {
             dashboard.getCurrentCase();
-            safeClickOn(unallocatedCaseView.allocateToMeLink);
+            safeClickOn(caseView.allocateToMeLink);
         }
         markup.moveCaseFromMarkupToInitialDraft();
     }
@@ -124,7 +124,7 @@ public class MarkupStepDefs extends BasePage {
 
     @Then("the case should be found in the {string} team")
     public void theCaseShouldBeFoundInTheTeamTeam(String team) {
-        goToDashboard();
+        dashboard.goToDashboard();
         switch (team.toUpperCase()) {
             case "PUBLIC PROTECTION UNIT":
                 safeClickOn(dashboard.publicProtectionUnit);

--- a/src/test/java/com/hocs/test/glue/dcu/MinisterialSignOffStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/MinisterialSignOffStepDefs.java
@@ -2,7 +2,7 @@ package com.hocs.test.glue.dcu;
 
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.dcu.MinisterialSignOff;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.When;
@@ -13,13 +13,13 @@ public class MinisterialSignOffStepDefs extends BasePage {
 
     MinisterialSignOff ministerialSignOff;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     @When("I complete the Ministerial Sign Off stage")
     public void completeTheMinisterSignOffStagePerCaseType() {
         if (!ministerialSignOff.ministerSignOffAcceptRadioButton.isVisible()) {
             dashboard.getCurrentCase();
-            safeClickOn(unallocatedCaseView.allocateToMeLink);
+            safeClickOn(caseView.allocateToMeLink);
         }
         safeClickOn(ministerialSignOff.ministerSignOffAcceptRadioButton);
         safeClickOn(continueButton);

--- a/src/test/java/com/hocs/test/glue/dcu/PrivateOfficeApprovalStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/PrivateOfficeApprovalStepDefs.java
@@ -10,7 +10,7 @@ import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.SummaryTab;
 import com.hocs.test.pages.decs.TimelineTab;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.dcu.AccordionDCU;
 import com.hocs.test.pages.dcu.PrivateOfficeApproval;
 import io.cucumber.java.en.And;
@@ -26,7 +26,7 @@ public class PrivateOfficeApprovalStepDefs extends BasePage {
 
     AccordionDCU accordionDCU;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     SummaryTab summaryTab;
 
@@ -40,7 +40,7 @@ public class PrivateOfficeApprovalStepDefs extends BasePage {
             case "DTEN":
                 if (!privateOfficeApproval.privateOfficeAcceptRadioButton.isVisible()) {
                     dashboard.getCurrentCase();
-                    safeClickOn(unallocatedCaseView.allocateToMeLink);
+                    safeClickOn(caseView.allocateToMeLink);
                 }
                 safeClickOn(privateOfficeApproval.privateOfficeAcceptRadioButton);
                 safeClickOn(continueButton);

--- a/src/test/java/com/hocs/test/glue/dcu/QAResponseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/QAResponseStepDefs.java
@@ -2,7 +2,7 @@ package com.hocs.test.glue.dcu;
 
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.Workstacks;
 import com.hocs.test.pages.dcu.QAResponse;
 import io.cucumber.java.en.And;
@@ -17,13 +17,13 @@ public class QAResponseStepDefs extends BasePage {
 
     Workstacks workstacks;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     @When("I complete the QA response stage")
     public void completeQAResponseStage() {
         if (!qaResponse.QAAcceptRadioButton.isVisible()) {
             dashboard.getCurrentCase();
-            safeClickOn(unallocatedCaseView.allocateToMeLink);
+            safeClickOn(caseView.allocateToMeLink);
         }
         safeClickOn(qaResponse.QAAcceptRadioButton);
         System.out.println("Finished QA Response, returning to home page.");

--- a/src/test/java/com/hocs/test/glue/decs/BaseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/BaseStepDefs.java
@@ -11,7 +11,7 @@ import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.PeopleTab;
 import com.hocs.test.pages.decs.SummaryTab;
 import com.hocs.test.pages.decs.TimelineTab;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.Workstacks;
 import com.hocs.test.pages.dcu.DataInput;
 import com.hocs.test.pages.dcu.Dispatch;
@@ -61,7 +61,7 @@ public class BaseStepDefs extends BasePage {
 
     User originalUser;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     @Then("the {string} page should be displayed")
     public void thePageShouldBeDisplayed(String pageTitle) {
@@ -277,7 +277,7 @@ public class BaseStepDefs extends BasePage {
     @Then("the case/claim should be closed")
     public void theCaseShouldBeClosed() {
         dashboard.getCurrentCase();
-        unallocatedCaseView.assertCaseCannotBeAssigned();
+        caseView.assertCaseCannotBeAssigned();
 //        if (!sessionVariableCalled("caseType").equals("WCS")) {
 //            timelineTab.selectTimelineTab();
 //            timelineTab.assertCaseClosedNoteVisible();
@@ -313,7 +313,7 @@ public class BaseStepDefs extends BasePage {
 
     @Then("the case/claim should be moved/returned to (the ){string}( stage)")
     public void assertCaseTypeMovedOrReturnedToStage(String stage) {
-        goToDashboard();
+        dashboard.goToDashboard();
         dashboard.getCurrentCase();
         summaryTab.selectSummaryTab();
         summaryTab.assertCaseStage(stage);

--- a/src/test/java/com/hocs/test/glue/decs/CaseDataStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/CaseDataStepDefs.java
@@ -4,15 +4,13 @@ import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.RecordCaseData;
 import com.hocs.test.pages.decs.SummaryTab;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.Workstacks;
 import io.cucumber.java.en.And;
 
 public class CaseDataStepDefs extends BasePage {
 
     RecordCaseData recordCaseData;
-
-    UnallocatedCaseView unallocatedCaseView;
 
     SummaryTab summaryTab;
 
@@ -26,7 +24,7 @@ public class CaseDataStepDefs extends BasePage {
             summaryTab.selectSummaryTab();
             summaryTab.assertSummaryContainsExpectedValueForGivenHeader("User", getCurrentUser().getUsername());
             String assignedTeam = summaryTab.getSummaryTabValueForGivenHeader("Team");
-            goToDashboard();
+            dashboard.goToDashboard();
             dashboard.selectWorkstackByTeamName(assignedTeam);
             workstacks.unallocateSelectedCase(getCurrentCaseReference());
             workstacks.selectSpecificCaseReferenceLink(getCurrentCaseReference());

--- a/src/test/java/com/hocs/test/glue/decs/CreateCaseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/CreateCaseStepDefs.java
@@ -12,7 +12,7 @@ import com.hocs.test.pages.decs.CreateCase_SuccessPage;
 import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.Documents;
 import com.hocs.test.pages.decs.SummaryTab;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.Workstacks;
 import com.hocs.test.pages.comp.Registration;
 import com.hocs.test.pages.dcu.DataInput;
@@ -53,7 +53,7 @@ public class CreateCaseStepDefs extends BasePage {
 
     Workstacks workstacks;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     Creation creation;
 
@@ -80,7 +80,7 @@ public class CreateCaseStepDefs extends BasePage {
     @Given("I create a single {string} case and return to the dashboard")
     public void createACaseTypeSpecificCase(String caseType) {
         createCase.createCSCaseOfType(caseType.toUpperCase());
-        goToDashboard();
+        dashboard.goToDashboard();
     }
 
     @When("I create a {string} case {string} a document")
@@ -252,7 +252,7 @@ public class CreateCaseStepDefs extends BasePage {
     public void iCreateACaseWithAsTheCorrespondent(String caseType, String correspondent) {
         createCase.createCSCaseOfType(caseType.toUpperCase());
         createCaseSuccessPage.goToCaseFromSuccessfulCreationScreen();
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
         dataInput.completeDataInputStageWithMPCorrespondent(correspondent);
     }
 
@@ -286,33 +286,33 @@ public class CreateCaseStepDefs extends BasePage {
             default:
                 pendingStep(caseType + " is not defined within " + getMethodName());
         }
-        unallocatedCaseView.allocateToUserByVisibleText(user.getAllocationText());
+        caseView.allocateToUserByVisibleText(user.getAllocationText());
         setSessionVariable("selectedUser").to(user);
     }
 
     @And("I create and claim a MPAM case with {string} as the Urgency level and {string} as the Reference Type")
     public void iCreateAndClaimAMPAMCaseWithAsTheUrgencyLevelAndAsTheReferenceType(String urgency, String refType) {
         iCreateAMPAMCaseWithAsTheUrgencyLevelAndAsTheReferenceType(urgency, refType);
-        waitForDashboard();
+        dashboard.waitForDashboard();
         dashboard.getAndClaimCurrentCase();
     }
 
     @And("I create a MPAM case with {string} as the Urgency level and {string} as the Reference Type")
     public void iCreateAMPAMCaseWithAsTheUrgencyLevelAndAsTheReferenceType(String urgency, String refType) {
         createCase.createCSCaseOfType("MPAM");
-        goToDashboard();
+        dashboard.goToDashboard();
         dashboard.getAndClaimCurrentCase();
         creation.moveCaseWithSpecifiedUrgencyAndRefTypeToTriageStage(urgency, refType);
-        waitForDashboard();
+        dashboard.waitForDashboard();
     }
 
     @And("I create a Ministerial MPAM case with {string} as the Ministerial Sign Off Team and move it to the Triage stage")
     public void iCreateAMinisterialMPAMCaseWithAsTheMinisterialSignOffTeam(String signOffTeam) {
         createCase.createCSCaseOfType("MPAM");
-        goToDashboard();
+        dashboard.goToDashboard();
         dashboard.getAndClaimCurrentCase();
         creation.moveCaseWithSpecificMinisterialSignOffTeamToTriageStage(signOffTeam);
-        waitForDashboard();
+        dashboard.waitForDashboard();
     }
 
     @And("I create a {string} case with {string} as its {string}")
@@ -331,7 +331,7 @@ public class CreateCaseStepDefs extends BasePage {
                         break;
                     case "MEMBER OF PARLIAMENT NAME":
                         createCase.createCSCaseOfType("MIN");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         dataInput.completeDataInputStageWithMPCorrespondent(infoValue);
                         break;
@@ -339,10 +339,10 @@ public class CreateCaseStepDefs extends BasePage {
                     case "CORRESPONDENT POSTCODE":
                     case "CORRESPONDENT EMAIL ADDRESS":
                         createCase.createCSCaseOfType("MIN");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         dataInput.completeDataInputStageWithPublicCorrespondent();
-                        waitForDashboard();
+                        dashboard.waitForDashboard();
                         break;
                     case "TOPIC":
                         iCreateACaseWithAsIts("DCU", "Gordon Freeman", "Public Correspondent Name");
@@ -357,7 +357,7 @@ public class CreateCaseStepDefs extends BasePage {
                         break;
                     case "HOME SECRETARY INTEREST":
                         createCase.createCSCaseOfType("MIN");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         if (infoValue.equalsIgnoreCase("YES")) {
                             dataInput.completeDataInputStageSpecifyingHomeSecInterest(true);
@@ -374,29 +374,29 @@ public class CreateCaseStepDefs extends BasePage {
                     case "CASE REFERENCE":
                     case "ACTIVE CASES ONLY":
                         createCase.createCSCaseOfType("MPAM");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "REFERENCE TYPE":
                         createCase.createCSCaseOfType("MPAM");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         creation.moveCaseWithSpecifiedBusinessAreaAndRefTypeToTriageStage("UKVI", infoValue);
                         break;
                     case "MINISTERIAL SIGN OFF TEAM":
                         createCase.createCSCaseOfType("MPAM");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         creation.moveCaseWithSpecificMinisterialSignOffTeamToTriageStage(infoValue);
                         break;
                     case "MEMBER OF PARLIAMENT NAME":
                         createCase.createCSCaseOfType("MPAM");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         creation.moveCaseWithSpecifiedMPCorrespondentToTriageStage(infoValue);
                         break;
                     case "CORRESPONDENT REFERENCE NUMBER":
                         createCase.createCSCaseOfType("MPAM");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         creation.moveCaseWithCorrespondentReferenceNumber(infoValue);
                         break;
@@ -408,7 +408,7 @@ public class CreateCaseStepDefs extends BasePage {
                         break;
                     case "CAMPAIGN":
                         createCase.createCSCaseOfType("MPAM");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         creation.moveCaseFromCreationToTriage();
                         dashboard.getAndClaimCurrentCase();
@@ -416,14 +416,14 @@ public class CreateCaseStepDefs extends BasePage {
                         break;
                     case "PUBLIC CORRESPONDENT NAME":
                         createCase.createCSCaseOfType("MPAM");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         creation.triggerMPCorrespondentIsMandatoryScreen();
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "TELEPHONE SURGERY OFFICIAL ENGAGEMENT":
                         createCase.createCSCaseOfType("MTS");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         dashboard.getAndClaimCurrentCase();
                         mtsDataInput.completeDataInputStageAndCloseMTSCase();
                         break;
@@ -487,7 +487,7 @@ public class CreateCaseStepDefs extends BasePage {
                     case "TOPIC":
                     case "ACTIVE CASES ONLY":
                         foiCreateCase.createFOICase();
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "RECEIVED ON OR AFTER":
                         dashboard.selectCreateSingleCaseLinkFromMenuBar();
@@ -505,7 +505,7 @@ public class CreateCaseStepDefs extends BasePage {
                         foiCreateCase.selectFOITopic("Animal alternatives (3Rs)");
                         foiCreateCase.enterRequestQuestion();
                         clickTheButton("Submit");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "RECEIVED ON OR BEFORE":
                         dashboard.selectCreateSingleCaseLinkFromMenuBar();
@@ -523,7 +523,7 @@ public class CreateCaseStepDefs extends BasePage {
                         foiCreateCase.selectFOITopic("Animal alternatives (3Rs)");
                         foiCreateCase.enterRequestQuestion();
                         clickTheButton("Submit");
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     default:
                         pendingStep(infoType + " is not defined within " + getMethodName());

--- a/src/test/java/com/hocs/test/glue/decs/EndToEndStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/EndToEndStepDefs.java
@@ -107,7 +107,7 @@ public class EndToEndStepDefs extends BasePage {
                     default:
                         pendingStep(stage + " is not defined within " + getMethodName());
                 }
-                waitForDashboard();
+                dashboard.waitForDashboard();
                 break;
             case "MPAM":
                 dashboard.getAndClaimCurrentCase();
@@ -139,7 +139,7 @@ public class EndToEndStepDefs extends BasePage {
                     default:
                         pendingStep(stage + " is not defined within " + getMethodName());
                 }
-                waitForDashboard();
+                dashboard.waitForDashboard();
                 break;
             case "COMP":
                 dashboard.getAndClaimCurrentCase();
@@ -213,7 +213,7 @@ public class EndToEndStepDefs extends BasePage {
                     default:
                         pendingStep(stage + " is not defined within " + getMethodName());
                 }
-                waitForDashboard();
+                dashboard.waitForDashboard();
                 break;
             case "FOI":
                 switch (stage.toUpperCase()) {
@@ -223,12 +223,12 @@ public class EndToEndStepDefs extends BasePage {
                         break;
                     case "ALLOCATION":
                         foiProgressCase.moveCaseFromAllocationToAcceptance();
-                        waitForDashboard();
+                        dashboard.waitForDashboard();
                         break;
                     case "ACCEPTANCE":
                         dashboard.getAndClaimCurrentCase();
                         foiProgressCase.moveCaseFromAcceptanceToConsiderAndDraft();
-                        waitForDashboard();
+                        dashboard.waitForDashboard();
                         break;
                     case "CONSIDER AND DRAFT":
                         dashboard.getAndClaimCurrentCase();
@@ -318,7 +318,7 @@ public class EndToEndStepDefs extends BasePage {
                     default:
                         pendingStep(stage + " is not defined within " + getMethodName());
                 }
-                waitForDashboard();
+                dashboard.waitForDashboard();
                 break;
             default:
                 pendingStep(caseType + " is not defined within " + getMethodName());
@@ -333,7 +333,7 @@ public class EndToEndStepDefs extends BasePage {
                 switch (stage.toUpperCase()) {
                     case "DATA INPUT":
                         createCase.createCSCaseOfType(caseType);
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "MARKUP":
                         iCreateACaseAndMoveItToAStage(caseType, "DATA INPUT");
@@ -379,7 +379,7 @@ public class EndToEndStepDefs extends BasePage {
                 switch (stage.toUpperCase()) {
                     case "DATA INPUT":
                         createCase.createCSCaseOfType(caseType);
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "MARKUP":
                         iCreateACaseAndMoveItToAStage(caseType, "DATA INPUT");
@@ -417,7 +417,7 @@ public class EndToEndStepDefs extends BasePage {
                 switch (stage.toUpperCase()) {
                     case "DATA INPUT":
                         createCase.createCSCaseOfType(caseType);
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "MARKUP":
                         iCreateACaseAndMoveItToAStage(caseType, "DATA INPUT");
@@ -459,7 +459,7 @@ public class EndToEndStepDefs extends BasePage {
                 switch (stage.toUpperCase()) {
                     case "CREATION":
                         createCase.createCSCaseOfType(caseType);
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "TRIAGE":
                         iCreateACaseAndMoveItToAStage(caseType, "CREATION");
@@ -499,13 +499,13 @@ public class EndToEndStepDefs extends BasePage {
                 break;
             case "MTS":
                 createCase.createCSCaseOfType(caseType);
-                goToDashboard();
+                dashboard.goToDashboard();
                 break;
             case "COMP":
                 switch (stage.toUpperCase()) {
                     case "REGISTRATION":
                         createCase.createCSCaseOfType(caseType);
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "SERVICE TRIAGE":
                         iCreateACaseAndMoveItToAStage(caseType, "REGISTRATION");
@@ -611,7 +611,7 @@ public class EndToEndStepDefs extends BasePage {
                 switch (stage.toUpperCase()) {
                     case "CASE CREATION":
                         foiCreateCase.createFOICase();
-                        goToDashboard();
+                        dashboard.goToDashboard();
                         break;
                     case "ALLOCATION":
                         iCreateACaseAndMoveItToAStage(caseType, "CASE CREATION");
@@ -655,7 +655,7 @@ public class EndToEndStepDefs extends BasePage {
                 iCreateACaseAndMoveItToAStage("MPAM", "CREATION");
                 dashboard.getAndClaimCurrentCase();
                 creation.moveCaseWithSpecifiedBusinessAreaAndRefTypeToTriageStage(businessArea, refType);
-                waitForDashboard();
+                dashboard.waitForDashboard();
                 break;
             case "DRAFT":
                 moveNewMPAMCaseWithSpecifiedBusinessAreaAndReferenceTypeToStage(businessArea, refType, "TRIAGE");
@@ -671,7 +671,7 @@ public class EndToEndStepDefs extends BasePage {
                 iCompleteTheStage("QA");
                 break;
             case "CASE CLOSED":
-                if (refType.toUpperCase().equals("MINISTERIAL")) {
+                if (refType.equalsIgnoreCase("MINISTERIAL")) {
                     moveNewMPAMCaseWithSpecifiedBusinessAreaAndReferenceTypeToStage(businessArea, refType, "PRIVATE OFFICE");
                     iCompleteTheStage("PRIVATE OFFICE (TO CASE CLOSED)");
                 } else {
@@ -698,10 +698,10 @@ public class EndToEndStepDefs extends BasePage {
         switch (stage.toUpperCase()) {
             case "TRIAGE":
                 createCase.createCaseWithSetCorrespondenceReceivedDate("MPAM", workdays.getDateXWorkdaysAgo(20));
-                goToDashboard();
+                dashboard.goToDashboard();
                 dashboard.getAndClaimCurrentCase();
                 creation.moveCaseWithSpecifiedUrgencyAndRefTypeToTriageStage("Immediate", "Ministerial");
-                waitForDashboard();
+                dashboard.waitForDashboard();
                 break;
             case "DRAFT":
                 moveHighPriorityNewMPAMCaseToStage("TRIAGE");

--- a/src/test/java/com/hocs/test/glue/decs/LoginStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/LoginStepDefs.java
@@ -58,7 +58,7 @@ public class LoginStepDefs extends BasePage {
         }
         else {
             System.out.println("Session still active, checking active user matches target user");
-            goToDashboard();
+            dashboard.goToDashboard();
             if (!loggedInAsTargetUser()) {
                 System.out.println("Active user does not match target user, logging out");
                 selectLogoutButton();
@@ -194,11 +194,11 @@ public class LoginStepDefs extends BasePage {
             } else {
                 dashboard.selectCreateSingleCaseLinkFromMenuBar();
                 targetUserLoggedIn = createCase.checkTargetUserIsLoggedInUsingCreateCasePage(targetUser);
-                goToDashboard();
+                dashboard.goToDashboard();
             }
         }
         else {
-            goToDashboard();
+            dashboard.goToDashboard();
             dashboard.selectMyCases();
             if (workstacks.getTotalOfCases() == 0) {
                 if (currentPlatform.equals("CS")){
@@ -208,7 +208,7 @@ public class LoginStepDefs extends BasePage {
                 else if (currentPlatform.equals("WCS")) {
                     createCase.createWCSCase();
                 }
-                goToDashboard();
+                dashboard.goToDashboard();
                 dashboard.selectMyCases();
             }
             targetUserLoggedIn = workstacks.ownerOfTopCaseInWorkstackIs(targetUser);

--- a/src/test/java/com/hocs/test/glue/decs/NavigationStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/NavigationStepDefs.java
@@ -54,8 +54,8 @@ public class NavigationStepDefs extends BasePage {
 
     @And ("I click to view( the case/claim in) the {string} workstack")
     public void iClickToViewTheWorkstack(String workstackIdentifier) {
-        if (!onDashboard()) {
-            goToDashboard();
+        if (!dashboard.onDashboard()) {
+            dashboard.goToDashboard();
         }
         if (workstackIdentifier.equalsIgnoreCase("My Cases")) {
             dashboard.selectMyCases();

--- a/src/test/java/com/hocs/test/glue/decs/SearchStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/SearchStepDefs.java
@@ -9,7 +9,7 @@ import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.CreateCase;
 import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.Search;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.Workstacks;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
@@ -28,7 +28,7 @@ public class SearchStepDefs extends BasePage {
 
     CreateCase createCase;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     @When("I click the search button on the search page")
     public void clickSearchButtonOnSearchPageWithNoCriteria() {
@@ -55,7 +55,7 @@ public class SearchStepDefs extends BasePage {
     @When("I enter a valid case reference into the load case search bar")
     public void enterValidCaseReferenceForSearch() {
         createCase.createCSCaseOfType("MIN");
-        goToDashboard();
+        dashboard.goToDashboard();
         dashboard.enterCaseReferenceIntoSearchBar(getCurrentCaseReference());
         dashboard.hitEnterCaseReferenceSearchBar();
     }
@@ -63,7 +63,7 @@ public class SearchStepDefs extends BasePage {
     @Then("I should be taken directly to the case")
     public void assertThatCaseReferenceSearchTakesUserToCase() {
         workstacks.waitABit(500);
-        if (workstacks.isElementDisplayed(unallocatedCaseView.allocateToMeLink)) {
+        if (workstacks.isElementDisplayed(caseView.allocateToMeLink)) {
             workstacks.assertCaseReferenceBeforeAllocation();
         } else {
             workstacks.assertCaseReferenceAfterAllocation();

--- a/src/test/java/com/hocs/test/glue/decs/ValidationStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/ValidationStepDefs.java
@@ -1,5 +1,6 @@
 package com.hocs.test.glue.decs;
 
+import com.hocs.test.pages.comp.COMPSend;
 import com.hocs.test.pages.decs.AddCorrespondent;
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Documents;
@@ -79,6 +80,8 @@ public class ValidationStepDefs extends BasePage {
     ComplaintClosed complaintClosed;
 
     CCH cch;
+
+    COMPSend compSend;
 
     @And("I trigger the {string} error message at (the ){string}( stage)")
     public void iTriggerTheErrorMessageAtTheStage(String errorMessage, String stage) {
@@ -1337,12 +1340,28 @@ public class ValidationStepDefs extends BasePage {
                         }
                         break;
                     case "SERVICE SEND":
-                            if (errorMessage.equalsIgnoreCase("CASE OUTCOME REQUIRED")) {
+                        switch (errorMessage.toUpperCase()) {
+                            case "CASE OUTCOME REQUIRED":
                                 waitABit(500);
+                                compSend.selectAResponseChannel();
+                                compSend.enterADateOfResponse();
                                 clickTheButton("Complete");
-                            } else {
+                                break;
+                            case "RESPONSE CHANNEL REQUIRED":
+                                waitABit(500);
+                                compSend.selectACaseOutcome();
+                                compSend.enterADateOfResponse();
+                                clickTheButton("Complete");
+                                break;
+                            case "DATE OF RESPONSE REQUIRED":
+                                waitABit(500);
+                                compSend.selectACaseOutcome();
+                                compSend.selectAResponseChannel();
+                                clickTheButton("Complete");
+                                break;
+                            default:
                                 pendingStep(errorMessage + " is not defined within " + getMethodName());
-                            }
+                        }
                         break;
                     case "COMPLAINT CLOSED":
                         switch (errorMessage.toUpperCase()) {

--- a/src/test/java/com/hocs/test/glue/decs/WorkstacksStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/WorkstacksStepDefs.java
@@ -138,7 +138,7 @@ public class WorkstacksStepDefs extends BasePage {
     @And("I create a new case and view it in the Performance and Process team workstack")
     public void iCreateANewCaseAndViewItInThePerformanceAndProcessTeamWorkstack() {
         createCase.createCSCaseOfType("MIN");
-        goToDashboard();
+        dashboard.goToDashboard();
         safeClickOn(dashboard.performanceProcessTeam);
         waitABit(1000);
     }
@@ -168,15 +168,15 @@ public class WorkstacksStepDefs extends BasePage {
     public void createThreeCasesAndReassign() {
         createCase.createCSCaseOfType("TRO");
         setSessionVariable("caseReference1").to(getCurrentCaseReference());
-        goToDashboard();
+        dashboard.goToDashboard();
         waitABit(1000);
         createCase.createCSCaseOfType("TRO");
         setSessionVariable("caseReference2").to(getCurrentCaseReference());
-        goToDashboard();
+        dashboard.goToDashboard();
         waitABit(1000);
         createCase.createCSCaseOfType("TRO");
         setSessionVariable("caseReference3").to(getCurrentCaseReference());
-        goToDashboard();
+        dashboard.goToDashboard();
         waitABit(1000);
         safeClickOn(dashboard.performanceProcessTeam);
     }
@@ -198,7 +198,7 @@ public class WorkstacksStepDefs extends BasePage {
             createCase.createCSCaseOfType("TRO");
             safeClickOn(createCaseSuccessPage.newCaseReference);
             workstacks.caseDetailsSelectAllocationUserByVisibleText(User.valueOf(user).getAllocationText());
-            goToDashboard();
+            dashboard.goToDashboard();
             n++;
         }
     }
@@ -307,7 +307,7 @@ public class WorkstacksStepDefs extends BasePage {
 
     @And("I view the MPAM case in the appropriate {string} stage workstack")
     public void iViewTheCaseInTheWorkstack(String stage) {
-        goToDashboard();
+        dashboard.goToDashboard();
         dashboard.selectCorrectMPAMTeamByStage(stage);
     }
 
@@ -360,7 +360,7 @@ public class WorkstacksStepDefs extends BasePage {
     @Then("the earliest due date of the contribution requests is displayed in workstacks")
     public void theEarliestDueDateOfTheContributionRequestsIsDisplayed() {
         waitABit(1000);
-        goToDashboard();
+        dashboard.goToDashboard();
         iEnterAWorkstack("MPAM Draft");
         workstacks.assertDueDateOfContributionRequest();
     }
@@ -379,7 +379,7 @@ public class WorkstacksStepDefs extends BasePage {
                 } else {
                     createCase.createCSCaseOfType("MIN");
                     createCaseSuccessPage.allocateToMeViaSuccessfulCreationScreen();
-                    goToDashboard();
+                    dashboard.goToDashboard();
                     dashboard.selectMyCases();
                 }
                 break;
@@ -388,7 +388,7 @@ public class WorkstacksStepDefs extends BasePage {
                     dashboard.selectTransferN10Team();
                 } catch (NoSuchElementException e) {
                     createCase.createCSCaseOfType("MIN");
-                    goToDashboard();
+                    dashboard.goToDashboard();
                     dashboard.selectPerformanceProcessTeam();
                 }
                 break;
@@ -397,7 +397,7 @@ public class WorkstacksStepDefs extends BasePage {
                     dashboard.selectMyCases();
                 } catch (NoSuchElementException e) {
                     createCase.createCSCaseOfType("MPAM");
-                    goToDashboard();
+                    dashboard.goToDashboard();
                     dashboard.selectMyCases();
                 }
                 break;
@@ -406,7 +406,7 @@ public class WorkstacksStepDefs extends BasePage {
                     dashboard.selectMTSTeam();
                 } catch (NoSuchElementException e) {
                     createCase.createCSCaseOfType("MTS");
-                    goToDashboard();
+                    dashboard.goToDashboard();
                     dashboard.selectMTSTeam();
                 }
                 break;
@@ -421,7 +421,7 @@ public class WorkstacksStepDefs extends BasePage {
                     dashboard.selectCorrectMPAMTeamByStage(stage);
                 } catch (NoSuchElementException e) {
                     endToEndStepDefs.iCreateACaseAndMoveItToAStage("MPAM", stage);
-                    goToDashboard();
+                    dashboard.goToDashboard();
                     dashboard.selectCorrectMPAMTeamByStage(stage);
                 }
                 break;
@@ -494,7 +494,7 @@ public class WorkstacksStepDefs extends BasePage {
 
     @Then("the rejected column of the case in the {string} workstack should display rejected by {string}")
     public void theRejectedColumnOfTheCaseInTheWorkstackShouldDisplayRejectedBy(String workstack, String rejectionStage) {
-        goToDashboard();
+        dashboard.goToDashboard();
         dashboard.selectWorkstackByTeamName(workstack);
         workstacks.assertRejectedColumnContainsStage(rejectionStage);
     }

--- a/src/test/java/com/hocs/test/glue/ukvi/DraftStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/ukvi/DraftStepDefs.java
@@ -4,6 +4,7 @@ import static jnr.posix.util.MethodName.getMethodName;
 import static net.serenitybdd.core.Serenity.pendingStep;
 
 import com.hocs.test.pages.decs.BasePage;
+import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.ukvi.Draft;
 import com.hocs.test.pages.ukvi.MPAMMultipleContributions;
 import io.cucumber.java.en.And;
@@ -14,6 +15,8 @@ public class DraftStepDefs extends BasePage {
     Draft draft;
 
     MPAMMultipleContributions MPAMMultipleContributions;
+
+    Dashboard dashboard;
 
     @And("I move a Official case from Draft to Dispatch bypassing QA")
     public void moveBRefCaseFromDraftToDispatch() {
@@ -42,7 +45,7 @@ public class DraftStepDefs extends BasePage {
             default:
                 pendingStep(action + " is not defined within " + getMethodName());
         }
-        waitForDashboard();
+        dashboard.waitForDashboard();
     }
 
     @When("I take the Draft \\(On Hold) case off hold")

--- a/src/test/java/com/hocs/test/glue/ukvi/QAStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/ukvi/QAStepDefs.java
@@ -4,12 +4,15 @@ import static jnr.posix.util.MethodName.getMethodName;
 import static net.serenitybdd.core.Serenity.pendingStep;
 
 import com.hocs.test.pages.decs.BasePage;
+import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.ukvi.QA;
 import io.cucumber.java.en.And;
 
 public class QAStepDefs extends BasePage {
 
     QA qa;
+
+    Dashboard dashboard;
 
     @And("I select the {string} action at QA")
     public void iSelectOptionAtQA(String action) {
@@ -131,6 +134,6 @@ public class QAStepDefs extends BasePage {
     @And("I submit a reason to escalate the case at QA stage")
     public void iSubmitAReasonToEscalateTheCaseAtQAStage() {
         qa.submitReasonToEscalateCase("test reason to escalate case");
-        waitForDashboard();
+        dashboard.waitForDashboard();
     }
 }

--- a/src/test/java/com/hocs/test/glue/ukvi/TriageStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/ukvi/TriageStepDefs.java
@@ -5,6 +5,7 @@ import static net.serenitybdd.core.Serenity.pendingStep;
 import static net.serenitybdd.core.Serenity.sessionVariableCalled;
 
 import com.hocs.test.pages.decs.BasePage;
+import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.SummaryTab;
 import com.hocs.test.pages.ukvi.AccordionMPAM;
 import com.hocs.test.pages.ukvi.Creation;
@@ -26,6 +27,8 @@ public class TriageStepDefs extends BasePage {
 
     SummaryTab summaryTab;
 
+    Dashboard dashboard;
+
     @And("I send the Triage case to {string}")
     public void sendTheTriageCaseTo(String stage) {
         switch (stage.toUpperCase()) {
@@ -46,7 +49,7 @@ public class TriageStepDefs extends BasePage {
             default:
                 pendingStep(stage + " is not defined within " + getMethodName());
         }
-        waitForDashboard();
+        dashboard.waitForDashboard();
     }
 
     @And("I select the {string} enquiry subject and continue")

--- a/src/test/java/com/hocs/test/pages/comp/COMPProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/comp/COMPProgressCase.java
@@ -203,17 +203,26 @@ public class COMPProgressCase extends BasePage {
     }
 
     public void moveCaseFromServiceSendToComplaintClosed() {
-        compSend.submitASelectedOutcome();
+        compSend.selectACaseOutcome();
+        compSend.selectAResponseChannel();
+        compSend.enterADateOfResponse();
+        clickTheButton("Continue");
         System.out.println("Case moved from Service Send to Complaint Closed");
     }
 
     public void moveCaseFromExGratiaSendToComplaintClosed() {
-        compSend.submitASelectedOutcome();
+        compSend.selectACaseOutcome();
+        compSend.selectAResponseChannel();
+        compSend.enterADateOfResponse();
+        clickTheButton("Continue");
         System.out.println("Case moved from Ex-Gratia Send to Complaint Closed");
     }
 
     public void moveCaseFromMinorMisconductSendToComplaintClosed() {
-        compSend.submitASelectedOutcome();
+        compSend.selectACaseOutcome();
+        compSend.selectAResponseChannel();
+        compSend.enterADateOfResponse();
+        clickTheButton("Continue");
         System.out.println("Case moved from Minor Misconduct Send to Complaint Closed");
     }
 

--- a/src/test/java/com/hocs/test/pages/comp/COMPSend.java
+++ b/src/test/java/com/hocs/test/pages/comp/COMPSend.java
@@ -12,8 +12,15 @@ public class COMPSend extends BasePage {
     @FindBy(id = "CctCaseOutcome")
     public WebElementFacade caseOutcomeDropdown;
 
-    public void submitASelectedOutcome() {
+    public void selectACaseOutcome() {
         recordCaseData.selectRandomOptionFromDropdownWithHeading("Case Outcome");
-        clickTheButton("Complete");
+    }
+
+    public void selectAResponseChannel() {
+        recordCaseData.selectRandomOptionFromDropdownWithHeading("Response Channel");
+    }
+
+    public void enterADateOfResponse() {
+        recordCaseData.enterDateIntoDateFieldsWithHeading(getDatePlusMinusNDaysAgo(-1), "Date of Response");
     }
 }

--- a/src/test/java/com/hocs/test/pages/dcu/fetchExistingDCUCases.java
+++ b/src/test/java/com/hocs/test/pages/dcu/fetchExistingDCUCases.java
@@ -8,7 +8,7 @@ import static net.serenitybdd.core.Serenity.setSessionVariable;
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.CreateCase;
 import com.hocs.test.pages.decs.Dashboard;
-import com.hocs.test.pages.decs.UnallocatedCaseView;
+import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.Workstacks;
 import net.serenitybdd.core.pages.WebElementFacade;
 import net.thucydides.core.webdriver.exceptions.ElementShouldBeEnabledException;
@@ -34,7 +34,7 @@ public class fetchExistingDCUCases extends BasePage {
 
     Workstacks workstacks;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     private void getFirstUnallocatedMINCaseDataInputStage() {
         workstacks.waitForWorkstackToLoad();
@@ -43,7 +43,7 @@ public class fetchExistingDCUCases extends BasePage {
                         + "Input')]][following-sibling::td[2]"
                         + "[not(text())]][descendant::a[contains(text(), 'MIN')]]").get(0);
         safeClickOn(firstUnallocatedMINCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedTROCaseDataInputStage() {
@@ -51,7 +51,7 @@ public class fetchExistingDCUCases extends BasePage {
         WebElementFacade firstUnallocatedTROCase = findAll("//td[following-sibling::td[1][contains(text(), 'Data Input')"
                 + "]][following-sibling::td[2][not(text())]][descendant::a[contains(text(), 'TRO')]]").get(0);
         safeClickOn(firstUnallocatedTROCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedDTENCaseDataInputStage() {
@@ -60,7 +60,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "]][following-sibling::td[2][not(text())]][descendant::a[contains(text(), 'DTEN')]]")
                 .get(0);
         safeClickOn(firstUnallocatedDTENCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedMINCaseMarkupStage() {
@@ -69,10 +69,10 @@ public class fetchExistingDCUCases extends BasePage {
                 + "'Markup')]][following-sibling::td[2]"
                 + "[not(text())]][descendant::a[contains(text(), 'MIN')]]").get(0);
         String caseRef = firstUnallocatedMINCase.getText().split("\\r?\\n")[1];
-        goToDashboard();
+        dashboard.goToDashboard();
         dashboard.caseReferenceSearchBar.sendKeys(caseRef);
         dashboard.hitEnterCaseReferenceSearchBar();
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedTROCaseMarkupStage() {
@@ -80,7 +80,7 @@ public class fetchExistingDCUCases extends BasePage {
         WebElementFacade firstUnallocatedTROCase = findAll("//td[following-sibling::td[1][contains(text(), 'Markup')"
                 + "]][following-sibling::td[2][not(text())]][descendant::a[contains(text(), 'TRO')]]").get(0);
         safeClickOn(firstUnallocatedTROCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedDTENCaseMarkupStage() {
@@ -89,7 +89,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "]][following-sibling::td[2][not(text())]][descendant::a[contains(text(), 'DTEN')]]")
                 .get(0);
         safeClickOn(firstUnallocatedDTENCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedMINCaseInitialDraftStage() {
@@ -98,7 +98,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "'Initial Draft')]][following-sibling::td[2]"
                 + "[not(text())]][descendant::a[contains(text(), 'MIN')]]").get(0);
         safeClickOn(firstUnallocatedMINCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedTROCaseInitialDraftStage() {
@@ -107,7 +107,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "Draft')]][following-sibling::td[2][not(text())]][descendant::a[contains(text(), 'TRO')"
                 + "]]").get(0);
         safeClickOn(firstUnallocatedTROCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedDTENCaseInitialDraftStage() {
@@ -116,7 +116,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "]][following-sibling::td[2][not(text())]][descendant::a[contains(text(), 'DTEN')]]")
                 .get(0);
         safeClickOn(firstUnallocatedDTENCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedMINCaseQAResponseStage() {
@@ -125,7 +125,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "'QA Response')]][following-sibling::td[2]"
                 + "[not(text())]][descendant::a[contains(text(), 'MIN')]]").get(0);
         safeClickOn(firstUnallocatedMINCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedTROCaseQAResponse() {
@@ -133,7 +133,7 @@ public class fetchExistingDCUCases extends BasePage {
         WebElementFacade firstUnallocatedTROCase = findAll("//td[following-sibling::td[1][contains(text(), 'QA Response')"
                 + "]][following-sibling::td[2][not(text())]][descendant::a[contains(text(), 'TRO')]]").get(0);
         safeClickOn(firstUnallocatedTROCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedDTENCaseQAResponseStage() {
@@ -142,7 +142,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "]][following-sibling::td[2][not(text())]][descendant::a[contains(text(), 'DTEN')]]")
                 .get(0);
         safeClickOn(firstUnallocatedDTENCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedMINCasePrivateOfficeStage() {
@@ -151,7 +151,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "'Private Office Approval')]][following-sibling::td[2]"
                 + "[not(text())]][descendant::a[contains(text(), 'MIN')]]").get(0);
         safeClickOn(firstUnallocatedMINCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedDTENCasePrivateOfficeStage() {
@@ -160,7 +160,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "'Private Office')]][following-sibling::td[2]"
                 + "[not(text())]][descendant::a[contains(text(), 'DTEN')]]").get(0);
         safeClickOn(firstUnallocatedDTENCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedMINCaseMinisterialSignOffStage() {
@@ -169,7 +169,7 @@ public class fetchExistingDCUCases extends BasePage {
                 + "'Ministerial Sign off')]][following-sibling::td[2]"
                 + "[not(text())]][descendant::a[contains(text(), 'MIN')]]").get(0);
         safeClickOn(firstUnallocatedMINCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedMINCaseDispatchStage() {
@@ -178,7 +178,7 @@ public class fetchExistingDCUCases extends BasePage {
                 "//td[following-sibling::td[1][contains(text(), 'Dispatch')]][following-sibling::td[2]"
                         + "[not(text())]][descendant::a[contains(text(), 'MIN')]]").get(0);
         safeClickOn(firstUnallocatedMINCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedTROCaseDispatchStage() {
@@ -186,7 +186,7 @@ public class fetchExistingDCUCases extends BasePage {
         WebElementFacade firstUnallocatedTROCase = findAll("//td[following-sibling::td[1][contains(text(), 'Dispatch')"
                 + "]][following-sibling::td[2][not(text())]][descendant::a[contains(text(), 'TRO')]]").get(0);
         safeClickOn(firstUnallocatedTROCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     private void getFirstUnallocatedDTENCaseDispatchStage() {
@@ -195,7 +195,7 @@ public class fetchExistingDCUCases extends BasePage {
                 "//td[following-sibling::td[1][contains(text(), 'Dispatch')]][following-sibling::td[2]"
                         + "[not(text())]][descendant::a[contains(text(), 'DTEN')]]").get(0);
         safeClickOn(firstUnallocatedDTENCase);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     public void giveMeACase(String caseType, String stage) {
@@ -332,7 +332,7 @@ public class fetchExistingDCUCases extends BasePage {
                     safeClickOn(dashboard.centralDraftingTeam);
                 } catch (ElementShouldBeEnabledException e) {
                     System.out.println("Central Drafting Team not available -  Searching for a Data Input case");
-                    goToDashboard();
+                    dashboard.goToDashboard();
                     getFirstUnallocatedDataInputCase(caseType);
                     dataInput.moveCaseFromDataInputToMarkup();
                     String thisCaseType = sessionVariableCalled("caseType").toString();

--- a/src/test/java/com/hocs/test/pages/decs/BasePage.java
+++ b/src/test/java/com/hocs/test/pages/decs/BasePage.java
@@ -175,46 +175,6 @@ public class BasePage extends PageObject {
         safeClickOn(continueButton);
     }
 
-    private void goToCSDashboard() {
-        safeClickOn(csDashboardLink);
-        waitForDashboard();
-    }
-
-    private void goToWCSDashboard() {
-        safeClickOn(wcsDashboardLink);
-        waitForDashboard();
-    }
-
-    public void waitForDashboard() {
-        caseReferenceSearchBar.withTimeoutOf(Duration.ofSeconds(60)).waitUntilVisible();
-    }
-
-    public boolean onDashboard() {
-        return caseReferenceSearchBar.isCurrentlyVisible();
-    }
-
-    public void goToMUIDashboard() {
-        safeClickOn(muiDashboardLink);
-    }
-
-    public void goToDashboard() {
-
-        switch (currentPlatform.toUpperCase()) {
-            case "CS":
-                goToCSDashboard();
-                break;
-            case "WCS":
-                goToWCSDashboard();
-                break;
-            case "CS MANAGEMENT UI":
-            case "WCS MANAGEMENT UI":
-                goToMUIDashboard();
-                break;
-            default:
-                pendingStep(currentPlatform + " is not defined within " + getMethodName());
-        }
-    }
-
     public void clickRejectButton() {
         safeClickOn(rejectButton);
     }
@@ -349,26 +309,6 @@ public class BasePage extends PageObject {
 
     public String getCurrentCaseReference() {
         return sessionVariableCalled("caseReference");
-    }
-
-    public boolean currentCaseIsLoaded() {
-        if (header1.isCurrentlyVisible()) {
-            try {
-                if (header1.getText().equals(getCurrentCaseReference())) {
-                    return true;
-                }
-            } catch (NoSuchElementException | StaleElementReferenceException | ElementNotVisibleException e) {
-                return false;
-            }
-        }
-        if (headerCaption1.isCurrentlyVisible()) {
-            try {
-                return headerCaption1.getText().equals(getCurrentCaseReference());
-            } catch (NoSuchElementException | StaleElementReferenceException | ElementNotVisibleException e) {
-                return false;
-            }
-        }
-        return false;
     }
 
     public void safeClickOn(WebElementFacade webElementFacade) {

--- a/src/test/java/com/hocs/test/pages/decs/CaseView.java
+++ b/src/test/java/com/hocs/test/pages/decs/CaseView.java
@@ -4,12 +4,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static net.serenitybdd.core.Serenity.sessionVariableCalled;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import net.serenitybdd.core.annotations.findby.FindBy;
 import net.serenitybdd.core.pages.WebElementFacade;
+import org.openqa.selenium.ElementNotVisibleException;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
 
-public class UnallocatedCaseView extends BasePage {
+public class CaseView extends BasePage {
 
     @FindBy(linkText = "Allocate to me")
     public WebElementFacade allocateToMeLink;
@@ -25,6 +29,9 @@ public class UnallocatedCaseView extends BasePage {
 
     @FindBy(xpath = "//h2[contains(@class,'section-heading')]/button[text()='Case Details']")
     public WebElementFacade wcsCaseDetailsAccordion;
+
+    @FindBy(xpath = "//div[@class='tabs']")
+    public WebElementFacade tabs;
 
     // Basic methods
 
@@ -65,5 +72,32 @@ public class UnallocatedCaseView extends BasePage {
         } else {
             return csCaseDetailsAccordion.isCurrentlyVisible();
         }
+    }
+
+    public void waitForCaseToLoad() {
+        tabs.withTimeoutOf(Duration.ofSeconds(60)).waitUntilVisible();
+    }
+
+    public boolean currentCaseIsLoaded() {
+        if (!tabs.isCurrentlyVisible()) {
+            return false;
+        }
+        if (header1.isCurrentlyVisible()) {
+            try {
+                if (header1.getText().equals(getCurrentCaseReference())) {
+                    return true;
+                }
+            } catch (NoSuchElementException | StaleElementReferenceException | ElementNotVisibleException e) {
+                return false;
+            }
+        }
+        if (headerCaption1.isCurrentlyVisible()) {
+            try {
+                return headerCaption1.getText().equals(getCurrentCaseReference());
+            } catch (NoSuchElementException | StaleElementReferenceException | ElementNotVisibleException e) {
+                return false;
+            }
+        }
+        return false;
     }
 }

--- a/src/test/java/com/hocs/test/pages/decs/CreateCase_SuccessPage.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase_SuccessPage.java
@@ -12,7 +12,7 @@ import static org.hamcrest.core.Is.is;
 
 public class CreateCase_SuccessPage extends BasePage {
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     @FindBy(className = "govuk-panel__body")
     private WebElementFacade panelBody;
@@ -42,7 +42,7 @@ public class CreateCase_SuccessPage extends BasePage {
 
     public void allocateToMeViaSuccessfulCreationScreen() {
         safeClickOn(newCaseReference);
-        safeClickOn(unallocatedCaseView.allocateToMeLink);
+        safeClickOn(caseView.allocateToMeLink);
     }
 
     public void goToCaseFromSuccessfulCreationScreen() {

--- a/src/test/java/com/hocs/test/pages/decs/RecordCaseData.java
+++ b/src/test/java/com/hocs/test/pages/decs/RecordCaseData.java
@@ -9,7 +9,7 @@ public class RecordCaseData extends BasePage{
 
     static HashMap<String, String> dataRecords = new HashMap<>();
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     public static void resetDataRecords() {
         dataRecords = new HashMap<>();
@@ -97,7 +97,7 @@ public class RecordCaseData extends BasePage{
 
     public void assertAllRecordedCaseDataIsDisplayedInTheReadOnlyAccordionSection() {
         for(HashMap.Entry<String, String> entry : dataRecords.entrySet()) {
-            List<String> visibleDisplayValues = unallocatedCaseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading(entry.getKey());
+            List<String> visibleDisplayValues = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading(entry.getKey());
             String recordedValue = entry.getValue();
             String expectedDisplayValue = recordedValue.replace("\n", " ");
             boolean expectedValueIsDisplayed = false;

--- a/src/test/java/com/hocs/test/pages/decs/Search.java
+++ b/src/test/java/com/hocs/test/pages/decs/Search.java
@@ -28,7 +28,7 @@ public class Search extends BasePage {
 
     AccordionMPAM accordionMPAM;
 
-    UnallocatedCaseView unallocatedCaseView;
+    CaseView caseView;
 
     Dashboard dashboard;
 
@@ -528,7 +528,7 @@ public class Search extends BasePage {
             case "CASE REFERENCE":
                 String caseRef;
                 safeClickOn(randomSearchResult);
-                if (unallocatedCaseView.allocateToMeLink.isVisible()) {
+                if (caseView.allocateToMeLink.isVisible()) {
                     caseRef = header1.getText();
                 } else {
                     caseRef = headerCaption1.getText();
@@ -617,17 +617,17 @@ public class Search extends BasePage {
                 break;
             case "COMPLAINANT DATE OF BIRTH":
                 safeClickOn(randomSearchResultHypertext);
-                if (!unallocatedCaseView.caseCanBeAllocated()) {
+                if (!caseView.caseCanBeAllocated()) {
                     summaryTab.selectSummaryTab();
                     summaryTab.assertSummaryContainsExpectedValueForGivenHeader("User",getCurrentUser().getUsername());
                     String assignedTeam = summaryTab.getSummaryTabValueForGivenHeader("Team");
-                    goToDashboard();
+                    dashboard.goToDashboard();
                     dashboard.selectWorkstackByTeamName(assignedTeam);
                     workstacks.unallocateSelectedCase(randomSearchResult);
                     workstacks.selectSpecificCaseReferenceLink(randomSearchResult);
                 }
                 openOrCloseAccordionSection("Registration");
-                displayedValue = unallocatedCaseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading("Date of Birth").get(0);
+                displayedValue = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading("Date of Birth").get(0);
                 expectedValue = sessionVariableCalled("searchComplainantDateOfBirth");
                 break;
             case "CASE REFERENCE":

--- a/src/test/resources/features/comp/COMPSend.feature
+++ b/src/test/resources/features/comp/COMPSend.feature
@@ -9,7 +9,8 @@ Feature: COMP Send
   Scenario: User can complete service send stage
     When I create a "COMP" case and move it to the "Service Send" stage
     And I load and claim the current case
-    And I select a Case Outcome at the "Service" Send stage
+    And I select a Case Outcome
+    And I submit the Response details
     Then the case should be moved to the "Complaint Closed" stage
     And the summary should display the owning team as "CCH Closed Cases"
     And the read-only Case Details accordion should contain all case information entered during the "Service Send" stage
@@ -18,7 +19,8 @@ Feature: COMP Send
   Scenario: User can complete Ex-Gratia send stage
     When I create a "COMP" case and move it to the "Ex-Gratia Send" stage
     And I load and claim the current case
-    And I select a Case Outcome at the "Ex-Gratia" Send stage
+    And I select a Case Outcome
+    And I submit the Response details
     Then the case should be moved to the "Complaint Closed" stage
     And the summary should display the owning team as "CCH Closed Cases"
 
@@ -26,7 +28,8 @@ Feature: COMP Send
   Scenario: User can complete Minor Misconduct send stage
     When I create a "COMP" case and move it to the "Minor Misconduct Send" stage
     And I load and claim the current case
-    And I select a Case Outcome at the "Minor Misconduct" Send stage
+    And I select a Case Outcome
+    And I submit the Response details
     Then the case should be moved to the "Complaint Closed" stage
     And the summary should display the owning team as "CCH Closed Cases"
 
@@ -37,5 +40,7 @@ Feature: COMP Send
     And I trigger the "<errorType>" error message at the "Service Send" stage
     Then the "<errorType>" error message is displayed at the "Service Send" stage
     Examples:
-      | errorType              |
-      | CASE OUTCOME REQUIRED  |
+      | errorType                 |
+      | CASE OUTCOME REQUIRED     |
+      | RESPONSE CHANNEL REQUIRED |
+      | DATE OF RESPONSE REQUIRED |

--- a/src/test/resources/features/comp/COMPTriage.feature
+++ b/src/test/resources/features/comp/COMPTriage.feature
@@ -190,10 +190,10 @@ Feature: COMP Triage
     Then the "<contributionType>" contribution request should be marked as "<action>"
     Examples:
       | contributionType | action   |
-#      | Complainant      | Complete |
+      | Complainant      | Complete |
       | Business         | Cancel   |
-#      | Complainant      | Complete |
-#      | Business         | Cancel   |
+      | Complainant      | Complete |
+      | Business         | Cancel   |
 
 #    HOCS-3103
   @COMPRegression

--- a/src/test/resources/features/comp/COMPTriage.feature
+++ b/src/test/resources/features/comp/COMPTriage.feature
@@ -43,8 +43,8 @@ Feature: COMP Triage
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
     And I accept the case at "Service" Triage stage
-    And I click the "Continue" button
-    And I click the "Continue" button
+    And I accept the previous Claim Category selection
+    And I accept the previous Severity selection
     And I enter details on the Triage Capture Reason page
     And I click the "Continue" button
     When I send the case to drafting
@@ -58,8 +58,8 @@ Feature: COMP Triage
     And I load and claim the current case
     And I accept the case at "Ex-Gratia" Triage stage
     And I select a "Ex-Gratia" Complaint Category
-    And I click the "Continue" button
-    And I click the "Continue" button
+    And I accept the previous Claim Category selection
+    And I accept the previous Severity selection
     And I enter details on the Triage Capture Reason page
     And I click the "Continue" button
     And I send the case to drafting
@@ -86,8 +86,8 @@ Feature: COMP Triage
       When I create a "COMP" case and move it to the "Service Triage" stage
       And I load and claim the current case
       And I accept the case at "Service" Triage stage
-      And I click the "Continue" button
-      And I click the "Continue" button
+    And I accept the previous Claim Category selection
+    And I accept the previous Severity selection
       And I enter details on the Triage Capture Reason page
       And I click the "Continue" button
       When I escalate the case to WFM at Service Triage stage
@@ -102,8 +102,8 @@ Feature: COMP Triage
     And I load and claim the current case
     And I accept the case at "Ex-Gratia" Triage stage
     And I select a "Ex-Gratia" Complaint Category
-    And I click the "Continue" button
-    And I click the "Continue" button
+    And I accept the previous Claim Category selection
+    And I accept the previous Severity selection
     And I enter details on the Triage Capture Reason page
     And I click the "Continue" button
     And I escalate the case to WFM at Service Triage stage
@@ -130,8 +130,8 @@ Feature: COMP Triage
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
     And I accept the case at "Service" Triage stage
-    And I click the "Continue" button
-    And I click the "Continue" button
+    And I accept the previous Claim Category selection
+    And I accept the previous Severity selection
     And I enter details on the Triage Capture Reason page
     And I click the "Continue" button
     When I select to complete the case at Service Triage
@@ -148,8 +148,8 @@ Feature: COMP Triage
     And I load and claim the current case
     And I accept the case at "Ex-Gratia" Triage stage
     And I select a "Ex-Gratia" Complaint Category
-    And I click the "Continue" button
-    And I click the "Continue" button
+    And I accept the previous Claim Category selection
+    And I accept the previous Severity selection
     And I enter details on the Triage Capture Reason page
     And I click the "Continue" button
     When I select to complete the case at Service Triage
@@ -181,8 +181,8 @@ Feature: COMP Triage
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
     And I accept the case at "Service" Triage stage
-    And I click the "Continue" button
-    And I click the "Continue" button
+    And I accept the previous Claim Category selection
+    And I accept the previous Severity selection
     And I enter details on the Triage Capture Reason page
     And I click the "Continue" button
     And I add a "<contributionType>" contribution request
@@ -190,10 +190,10 @@ Feature: COMP Triage
     Then the "<contributionType>" contribution request should be marked as "<action>"
     Examples:
       | contributionType | action   |
-      | Complainant      | Complete |
+#      | Complainant      | Complete |
       | Business         | Cancel   |
-      | Complainant      | Complete |
-      | Business         | Cancel   |
+#      | Complainant      | Complete |
+#      | Business         | Cancel   |
 
 #    HOCS-3103
   @COMPRegression
@@ -201,8 +201,8 @@ Feature: COMP Triage
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
     And I accept the case at "Service" Triage stage
-    And I click the "Continue" button
-    And I click the "Continue" button
+    And I accept the previous Claim Category selection
+    And I accept the previous Severity selection
     And I enter details on the Triage Capture Reason page
     And I click the "Continue" button
     And I add a "complainant" contribution with a due date in the past
@@ -215,8 +215,8 @@ Feature: COMP Triage
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
     And I accept the case at "Service" Triage stage
-    And I click the "Continue" button
-    And I click the "Continue" button
+    And I accept the previous Claim Category selection
+    And I accept the previous Severity selection
     And I select that a Letter of Authority is required
     And I click the "Continue" button
     And I can mark that the LoA was received and enter the LoA date

--- a/src/test/resources/features/ukvi1/Misallocations.feature
+++ b/src/test/resources/features/ukvi1/Misallocations.feature
@@ -9,7 +9,7 @@ Feature: Misallocations
     When I create a "MPAM" case and move it to the "<stage>" stage
     And I load and claim the current case
     And I select to transfer a case to "<transferTo>" at the "<stage>" stage
-    And I load and claim the current case
+    And I load the current case
     Then the case should be moved to the "Awaiting Transfer" stage
     And the reason for transfer is displayed in a case note in the case timeline
     Examples:
@@ -26,7 +26,7 @@ Feature: Misallocations
     And I create a single "MPAM" case and return to the dashboard
     And I load and claim the current case
     And I select to transfer a case to "OGD" at the "Creation" stage
-    And I load and claim the current case
+    And I load the current case
     And I select the "Transfer Rejected (Move to Triage)" action at the Awaiting Transfer stage
     And I complete the required fields for Triage and move the case to Triage
     Then the case should be moved to the "Triage" stage
@@ -36,7 +36,7 @@ Feature: Misallocations
     And I create a single "MPAM" case and return to the dashboard
     And I load and claim the current case
     And I select to transfer a case to "OGD" at the "Creation" stage
-    And I load and claim the current case
+    And I load the current case
     And I select the "Transfer Accepted (Close Case)" action at the Awaiting Transfer stage
     Then the case should be closed
 
@@ -45,7 +45,7 @@ Feature: Misallocations
     And I create a single "MPAM" case and return to the dashboard
     And I load and claim the current case
     And I select to transfer a case to "OGD" at the "Creation" stage
-    And I load and claim the current case
+    And I load the current case
     And I amend the Transfer due date of the case
     And I select the "Save Deadline for Transfer" action at the Awaiting Transfer stage
     And I navigate to the "Dashboard" page

--- a/src/test/resources/features/ukvi2/UKVISearch.feature
+++ b/src/test/resources/features/ukvi2/UKVISearch.feature
@@ -14,13 +14,13 @@ Feature: UKVI Search
     Then I check that the UKVI search results have the correct "<infoType>"
     Examples:
       | infoType                              | infoValue      |
-      | Reference Type                        | Ministerial    |
-      | Reference Type                        | Official       |
-      | Member of Parliament Name             | Boris Johnson  |
-      | Correspondent Reference Number        | TestRefNumber1 |
+#      | Reference Type                        | Ministerial    |
+#      | Reference Type                        | Official       |
+#      | Member of Parliament Name             | Boris Johnson  |
+#      | Correspondent Reference Number        | TestRefNumber1 |
       | Campaign                              | Small boats    |
-      | Ministerial Sign Off Team             | Home Secretary |
-      | Public Correspondent Name             | Sam McTester   |
+#      | Ministerial Sign Off Team             | Home Secretary |
+#      | Public Correspondent Name             | Sam McTester   |
 
 
   Scenario: User searches by case reference from the search page

--- a/src/test/resources/features/ukvi2/UKVISearch.feature
+++ b/src/test/resources/features/ukvi2/UKVISearch.feature
@@ -14,13 +14,13 @@ Feature: UKVI Search
     Then I check that the UKVI search results have the correct "<infoType>"
     Examples:
       | infoType                              | infoValue      |
-#      | Reference Type                        | Ministerial    |
-#      | Reference Type                        | Official       |
-#      | Member of Parliament Name             | Boris Johnson  |
-#      | Correspondent Reference Number        | TestRefNumber1 |
+      | Reference Type                        | Ministerial    |
+      | Reference Type                        | Official       |
+      | Member of Parliament Name             | Boris Johnson  |
+      | Correspondent Reference Number        | TestRefNumber1 |
       | Campaign                              | Small boats    |
-#      | Ministerial Sign Off Team             | Home Secretary |
-#      | Public Correspondent Name             | Sam McTester   |
+      | Ministerial Sign Off Team             | Home Secretary |
+      | Public Correspondent Name             | Sam McTester   |
 
 
   Scenario: User searches by case reference from the search page


### PR DESCRIPTION
…isible when either allocated or not.

Moved waitForCaseLoad to CaseView from Dashboard page.
Moved some mothods from BasePage to Dashboard, as they were dashboard specific, and it was making refactoring some higher level methods tricky/confusing.
Refactored dashboard.getAndClaimCurrentCase. We had logic in it that was checking if we were already on the current case before trying to load it from dashboard. This was causing race condition failures in scenarios, as the check might happen whilst the browser was moving between case view and dashboard. This method should only be used where we know we will want to load the case from the dashboard and then claim the case, we shouldnt have complex checks that allow part of that to be skipped. We have seperate getCurrentCase and claimCurrentCase that we can use in places where only one of the actions is required, and that will make the script of each scenario clearer. This change might cause some scenarios to fail if we have incorrectly used getAndClaimCurrentCase when we only needed claimCurrentCase, but this is desierable, as we would want to identify where we have incorrectly used it.