### PR TITLE
Added a wait to assertCaseDetailsAreCorrect in FOI/CaseCreationStage.…

### DIFF
--- a/src/test/java/com/hocs/test/pages/decs/CreateCase.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase.java
@@ -374,7 +374,8 @@ public class CreateCase extends BasePage {
     }
 
     public void selectCorrespondenceInboundChannel() {
-        String channel = recordCaseData.selectRandomRadioButtonFromGroupWithHeading("How was the request received?");
+        String channel = selectRandomRadioButtonFromGroupWithHeading("How was the request received?");
+        recordCaseData.addHeadingAndValueRecord("How was the correspondence received?", channel);
         setSessionVariable("foiInboundChannel").to(channel);
     }
 

--- a/src/test/java/com/hocs/test/pages/foi/CaseCreationStage.java
+++ b/src/test/java/com/hocs/test/pages/foi/CaseCreationStage.java
@@ -107,6 +107,7 @@ public class CaseCreationStage extends BasePage {
     }
 
     public void assertCaseDetailsAreCorrect() {
+        receivedDateValue.waitUntilVisible();
         String displayedReceivedDate = receivedDateValue.getText();
         String enteredReceivedDate = sessionVariableCalled("correspondenceReceivedDate");
         assertThat(displayedReceivedDate.equals(enteredReceivedDate), is(true));

--- a/src/test/java/com/hocs/test/pages/foi/FOIProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/foi/FOIProgressCase.java
@@ -70,7 +70,7 @@ public class FOIProgressCase extends BasePage {
         foiDispatch.selectDoYouWantToDispatch("Yes");
         foiDispatch.enterFinalResponseDate();
         clickTheButton("Continue");
-        documents.uploadDocumentOfType("Final responses");
+        documents.addADocumentOfType("Final responses");
         clickTheButton("Complete Dispatch");
         waitABit(500);
     }


### PR DESCRIPTION
…java

Amended moveCaseFromDispatchToSoftClose to correctly use documents.addADocumentOfType instead of documents.uploadDocumentOfType
Amended selectCorrespondenceInboundChannel to record the heading and values for accordion check correctly to match displayed text.