### PR TITLE
Test fixes from drone run 1718.

### DIFF
--- a/src/test/java/com/hocs/test/glue/dcu/PrivateOfficeApprovalStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/PrivateOfficeApprovalStepDefs.java
@@ -55,6 +55,7 @@ public class PrivateOfficeApprovalStepDefs extends BasePage {
         privateOfficeApproval.selectNewPrivateOfficeTeamFromDropdown(minister);
         privateOfficeApproval.enterAReasonForChangingPOTeam();
         safeClickOn(finishButton);
+        waitABit(2000);
     }
 
     @And("I advance the case to the Private Office Approval stage")

--- a/src/test/java/com/hocs/test/glue/decs/LoginStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/LoginStepDefs.java
@@ -179,7 +179,8 @@ public class LoginStepDefs extends BasePage {
     @Then("I should be logged in as the user {string}")
     public void iShouldBeLoggedInAsTheUser(String user) {
         targetUser = User.valueOf(user);
-        assert loggedInAsTargetUser();
+        Boolean loggedInAsCorrectUser = loggedInAsTargetUser();
+        assert loggedInAsCorrectUser;
     }
 
     private void checkForOverrideUser() {
@@ -218,6 +219,7 @@ public class LoginStepDefs extends BasePage {
         }
         return targetUserLoggedIn;
     }
+
     @And("I navigate to {string}")
     public void iNavigateTo(String platform) {
         navigateToPlatform(platform);

--- a/src/test/java/com/hocs/test/glue/decs/ManagementUIStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/ManagementUIStepDefs.java
@@ -362,6 +362,9 @@ waitABit(1000);
 
     @When("I add a new Standard Line with {string} as the topic")
     public void userAddsANewStandardLine(String topic) {
+        if (standardLine.addNewStandardLineButton.isCurrentlyVisible()) {
+            safeClickOn(standardLine.addNewStandardLineButton);
+        }
         standardLine.enterStandardLineTopic(topic);
         standardLine.addStandardLineDocument();
         standardLine.enterStandardLineExpirationDate();

--- a/src/test/java/com/hocs/test/glue/decs/NavigationStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/NavigationStepDefs.java
@@ -10,6 +10,8 @@ import com.hocs.test.pages.decs.CreateCase;
 import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.Search;
 import com.hocs.test.pages.dcu.DataInput;
+import com.hocs.test.pages.decs.SummaryTab;
+import com.hocs.test.pages.decs.Workstacks;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -27,6 +29,10 @@ public class NavigationStepDefs extends BasePage {
     Search search;
 
     CaseView caseView;
+
+    SummaryTab summaryTab;
+
+    Workstacks workstacks;
 
     @When("I navigate to the {string}( page)")
     public void iNavigateToThePage(String hocsPage) {
@@ -105,5 +111,15 @@ public class NavigationStepDefs extends BasePage {
     @Then("the case should be loaded")
     public void theCaseShouldBeLoaded() {
         caseView.currentCaseIsLoaded();
+    }
+
+    @And("I view the case/claim whilst not being the current owner")
+    public void iViewTheCaseWhilstNotBeingTheCurrentOwner() {
+        summaryTab.selectSummaryTab();
+        String currentTeam = summaryTab.getSummaryTabValueForGivenHeader("Team");
+        dashboard.goToDashboard();
+        dashboard.selectWorkstackByTeamName(currentTeam);
+        workstacks.unallocateSelectedCase(getCurrentCaseReference());
+        workstacks.selectSpecificCaseReferenceLink(getCurrentCaseReference());
     }
 }

--- a/src/test/java/com/hocs/test/pages/complaints/ComplaintsProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/complaints/ComplaintsProgressCase.java
@@ -267,7 +267,7 @@ public class ComplaintsProgressCase extends BasePage {
             WebElementFacade compCaseRefField = findBy("//a[contains(text(), 'Escalate case')]/parent::td/preceding-sibling::td/a");
             String compCaseRef = compCaseRefField.getText();
             setSessionVariable("compCaseReference").to(compCaseRef);
-            System.out.print("Case reference of case being escalated: " + compCaseRef);
+            System.out.print("Case reference of case being escalated: " + compCaseRef + "\n");
             search.clickEscalateCOMPCaseToCOMP2();
         } else {
             throw new Exception("Escalation hypertext not visible");

--- a/src/test/java/com/hocs/test/pages/decs/BasePage.java
+++ b/src/test/java/com/hocs/test/pages/decs/BasePage.java
@@ -215,7 +215,7 @@ public class BasePage extends PageObject {
 
     public boolean mtsCase() { return sessionVariableCalled("caseType").toString().equals("MTS"); }
 
-    public boolean complaintCase() { return compCase() | iedetCase() | smcCase(); }
+    public boolean complaintCase() { return compCase() | comp2Case() | iedetCase() | smcCase(); }
 
     public boolean compCase() { return sessionVariableCalled("caseType").toString().equals("COMP"); }
 

--- a/src/test/java/com/hocs/test/pages/decs/ConfirmationScreens.java
+++ b/src/test/java/com/hocs/test/pages/decs/ConfirmationScreens.java
@@ -48,7 +48,7 @@ public class ConfirmationScreens extends BasePage {
     public String storeCaseReference() {
         caseReference.withTimeoutOf(Duration.ofSeconds(20)).waitUntilVisible();
         String caseReference = this.caseReference.getAttribute("value");
-        System.out.println(caseReference + " is the case reference");
+        System.out.println("Case created: " + caseReference);
         setSessionVariable("caseReference").to(caseReference);
         return caseReference;
     }

--- a/src/test/java/com/hocs/test/pages/decs/CreateCase.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase.java
@@ -240,7 +240,7 @@ public class CreateCase extends BasePage {
     }
 
     public void createCSCaseOfRandomType() {
-        createCSCaseOfType(getRandomCaseType());
+        createCSCaseOfTypeWithoutDocument(getRandomCaseType());
     }
 
     public void createCSCaseOfTypeWithoutDocument(String caseType) {

--- a/src/test/java/com/hocs/test/pages/decs/Search.java
+++ b/src/test/java/com/hocs/test/pages/decs/Search.java
@@ -634,6 +634,7 @@ public class Search extends BasePage {
                 expectedValue = sessionVariableCalled("searchCaseType");
                 List<WebElementFacade> listOfCaseRefs = findAll("//td[2]/a[contains(text(), '" + expectedValue + "/')]");
                 assertThat(numberOfCasesDisplayed == listOfCaseRefs.size(), is(true));
+                displayedValue = "COMP2";
                 break;
             case "CORRESPONDENT FULL NAME":
                 cell = findBy("//a[text()='" + randomSearchResult + "']/parent::td/preceding-sibling::td");

--- a/src/test/java/com/hocs/test/pages/decs/SummaryTab.java
+++ b/src/test/java/com/hocs/test/pages/decs/SummaryTab.java
@@ -189,39 +189,39 @@ public class SummaryTab extends BasePage {
             case "MIN":
                 switch (stage.toUpperCase()) {
                     case "DATA INPUT":
-                        displayedDeadline = dataInputDeadlineDate.getText();
+                        displayedDeadline = dataInputDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 2;
                         break;
                     case "MARKUP":
-                        displayedDeadline = markupDeadlineDate.getText();
+                        displayedDeadline = markupDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 2;
                         break;
                     case "INITIAL DRAFT":
-                        displayedDeadline = initialDraftDeadlineDate.getText();
+                        displayedDeadline = initialDraftDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 10;
                         break;
                     case "QA RESPONSE":
-                        displayedDeadline = qaResponseDeadlineDate.getText();
+                        displayedDeadline = qaResponseDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 10;
                         break;
                     case "PRIVATE OFFICE APPROVAL":
-                        displayedDeadline = privateOfficeApprovalDeadlineDate.getText();
+                        displayedDeadline = privateOfficeApprovalDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 19;
                         break;
                     case "MINISTERIAL SIGN OFF":
-                        displayedDeadline = ministerialSignOffDeadlineDate.getText();
+                        displayedDeadline = ministerialSignOffDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 19;
                         break;
                     case "TRANSFER CONFIRMATION":
-                        displayedDeadline = transferConfirmationDeadlineDate.getText();
+                        displayedDeadline = transferConfirmationDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 20;
                         break;
                     case "NO RESPONSE NEEDED CONFIRMATION":
-                        displayedDeadline = noResponseNeededConfirmationDeadlineDate.getText();
+                        displayedDeadline = noResponseNeededConfirmationDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 20;
                         break;
                     case "DISPATCH":
-                        displayedDeadline = dispatchDeadlineDate.getText();
+                        displayedDeadline = dispatchDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 20;
                         break;
                     default:
@@ -233,11 +233,11 @@ public class SummaryTab extends BasePage {
                 String inputDeadline = null;
                 switch (stage.toUpperCase()) {
                     case "DISPATCH":
-                        displayedDeadline = dispatchDeadlineDate.getText();
+                        displayedDeadline = dispatchDeadlineDate.waitUntilVisible().getText();
                         inputDeadline = sessionVariableCalled("dtenDispatchDeadline");
                         break;
                     case "INITIAL DRAFT":
-                        displayedDeadline = initialDraftDeadlineDate.getText();
+                        displayedDeadline = initialDraftDeadlineDate.waitUntilVisible().getText();
                         inputDeadline = sessionVariableCalled("dtenInitialDraftDeadline");
                         break;
                     default:
@@ -248,35 +248,35 @@ public class SummaryTab extends BasePage {
             case "TRO":
                 switch (stage.toUpperCase()) {
                     case "DATA INPUT":
-                        displayedDeadline = dataInputDeadlineDate.getText();
+                        displayedDeadline = dataInputDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 2;
                         break;
                     case "MARKUP":
-                        displayedDeadline = markupDeadlineDate.getText();
+                        displayedDeadline = markupDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 2;
                         break;
                     case "INITIAL DRAFT":
-                        displayedDeadline = initialDraftDeadlineDate.getText();
+                        displayedDeadline = initialDraftDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 20;
                         break;
                     case "QA RESPONSE":
-                        displayedDeadline = qaResponseDeadlineDate.getText();
+                        displayedDeadline = qaResponseDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 20;
                         break;
                     case "TRANSFER CONFIRMATION":
-                        displayedDeadline = transferConfirmationDeadlineDate.getText();
+                        displayedDeadline = transferConfirmationDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 20;
                         break;
                     case "NO RESPONSE NEEDED CONFIRMATION":
-                        displayedDeadline = noResponseNeededConfirmationDeadlineDate.getText();
+                        displayedDeadline = noResponseNeededConfirmationDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 20;
                         break;
                     case "DISPATCH":
-                        displayedDeadline = dispatchDeadlineDate.getText();
+                        displayedDeadline = dispatchDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 20;
                         break;
                     case "COPY TO NUMBER 10":
-                        displayedDeadline = copyToNumber10DeadlineDate.getText();
+                        displayedDeadline = copyToNumber10DeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 20;
                         break;
                     default:
@@ -285,46 +285,46 @@ public class SummaryTab extends BasePage {
                 assertThat(checkDeadline(displayedDeadline, correspondenceReceivedDate, expectedNumberOfWorkdaysTillDeadline), is(true));
                 break;
             case "MPAM":
-                displayedDeadline = mpamDeadlineDate.getText();
+                displayedDeadline = mpamDeadlineDate.waitUntilVisible().getText();
                 expectedNumberOfWorkdaysTillDeadline = 20;
                 assertThat(checkDeadline(displayedDeadline, correspondenceReceivedDate, expectedNumberOfWorkdaysTillDeadline), is(true));
                 break;
             case "HOME SECRETARY SIGN-OFF":
                 switch (stage.toUpperCase()) {
                     case "DATA INPUT":
-                        displayedDeadline = dataInputDeadlineDate.getText();
+                        displayedDeadline = dataInputDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 2;
                         break;
                     case "MARKUP":
-                        displayedDeadline = markupDeadlineDate.getText();
+                        displayedDeadline = markupDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 2;
                         break;
                     case "INITIAL DRAFT":
-                        displayedDeadline = initialDraftDeadlineDate.getText();
+                        displayedDeadline = initialDraftDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 7;
                         break;
                     case "QA RESPONSE":
-                        displayedDeadline = qaResponseDeadlineDate.getText();
+                        displayedDeadline = qaResponseDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 7;
                         break;
                     case "PRIVATE OFFICE APPROVAL":
-                        displayedDeadline = privateOfficeApprovalDeadlineDate.getText();
+                        displayedDeadline = privateOfficeApprovalDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 9;
                         break;
                     case "MINISTERIAL SIGN OFF":
-                        displayedDeadline = ministerialSignOffDeadlineDate.getText();
+                        displayedDeadline = ministerialSignOffDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 9;
                         break;
                     case "TRANSFER CONFIRMATION":
-                        displayedDeadline = transferConfirmationDeadlineDate.getText();
+                        displayedDeadline = transferConfirmationDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 10;
                         break;
                     case "NO RESPONSE NEEDED CONFIRMATION":
-                        displayedDeadline = noResponseNeededConfirmationDeadlineDate.getText();
+                        displayedDeadline = noResponseNeededConfirmationDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 10;
                         break;
                     case "DISPATCH":
-                        displayedDeadline = dispatchDeadlineDate.getText();
+                        displayedDeadline = dispatchDeadlineDate.waitUntilVisible().getText();
                         expectedNumberOfWorkdaysTillDeadline = 10;
                         break;
                     default:

--- a/src/test/java/com/hocs/test/pages/decs/Workstacks.java
+++ b/src/test/java/com/hocs/test/pages/decs/Workstacks.java
@@ -180,7 +180,7 @@ public class Workstacks extends BasePage {
     }
 
     public boolean ownerOfTopCaseInWorkstackIs(User user) {
-        return getValueFromSpecifiedColumnForSpecifiedCase("Owner", getCurrentCaseReference()).contains(user.getUsername());
+        return getValueFromSpecifiedColumnForSpecifiedCase("Owner", topCaseReferenceHypertext.getText()).contains(user.getUsername());
     }
 
     private String getOwnerOfTopCaseInWorkstack() {

--- a/src/test/java/com/hocs/test/pages/foi/ActionsTab.java
+++ b/src/test/java/com/hocs/test/pages/foi/ActionsTab.java
@@ -72,9 +72,9 @@ public class ActionsTab extends BasePage {
         String appealType = recordCaseData.selectRandomOptionFromDropdownWithHeading("Which type of appeal needs to be applied?");
         setSessionVariable("appealType").to(appealType);
         if (appealType.equalsIgnoreCase("Internal Review")) {
-            String appealOfficerDirectorate = recordCaseData.selectRandomOptionFromDropdownWithHeading("Internal review officer directorate");
+            String appealOfficerDirectorate = recordCaseData.selectRandomOptionFromDropdownWithHeading("Directorate");
             setSessionVariable("appealOfficerDirectorate").to(appealOfficerDirectorate);
-            String appealOfficerName = recordCaseData.selectRandomOptionFromDropdownWithHeading("Internal review officer name");
+            String appealOfficerName = recordCaseData.selectRandomOptionFromDropdownWithHeading("Officer");
             setSessionVariable("appealOfficerName").to(appealOfficerName);
         }
         clickTheButton("Add Appeal");

--- a/src/test/java/com/hocs/test/pages/managementUI/StandardLine.java
+++ b/src/test/java/com/hocs/test/pages/managementUI/StandardLine.java
@@ -67,7 +67,7 @@ public class StandardLine extends BasePage {
     }
 
     public void addStandardLineDocument() {
-        upload("src/test/resources/documents/Standard line test.docx").to(standardLineDocumentButton);
+        upload("src/test/resources/documents/Standard Line test.docx").to(standardLineDocumentButton);
         setSessionVariable("standardLineDocument").to("Standard Line test.docx");
     }
 

--- a/src/test/resources/features/cs/ManagementUI.feature
+++ b/src/test/resources/features/cs/ManagementUI.feature
@@ -41,6 +41,7 @@ Feature: ManagementUI
   @StandardLines @DCURegression
   Scenario: User is able to amend the expiry date of a standard line
     When I select to "Manage standard lines"
+    And I add a new Standard Line with "Animal alternatives (3Rs)" as the topic
     And I amend the expiry date of the "Animal alternatives (3Rs)" standard line to 5 days from today
     Then the standard line expiry date has been correctly amended
 

--- a/src/test/resources/features/wcs/BroughtForwardDate.feature
+++ b/src/test/resources/features/wcs/BroughtForwardDate.feature
@@ -19,10 +19,7 @@ Feature: Brought Forward Date
   Scenario: User enters a brought forward date and view it in read-only case info
     When I fill in the case info including the Brought Forward Date: "01/01/2001"
     And I save changes to the claim
-    And I navigate to the "Dashboard" page
-    And I click to view the claim in the "My Cases" workstack
-    And I select the claim and unallocate it
-    And I click the link for the current case in the workstack
+    And I view the claim whilst not being the current owner
     And I open the case details accordion
     Then I check that the read-only case details accordion displays "01/01/2001" as the brought forward date
 


### PR DESCRIPTION
Added some extra waits.
Amended manage standard line scenario to have no data expectation.
Amended login check with extra line to be easier to debug.
Created re-usable step iViewTheCaseWhilstNotBeingTheCurrentOwner.
Added COMP2 into complaintCase check method.
Switched Manage Documents scenarios creation step to use method that doesnt add a document as case is created.
Amended ownerOfTopCaseInWorkstackIs so it correctly checks the top case, not try to check the current case (which might be null).
Updated labels for method to add an Appeal to a FOI case.
Fixed document file name in upload method for standard line scenario.