### PR TITLE
HOCS-3714 New FOI Superuser role type Required

### DIFF
--- a/src/test/java/config/User.java
+++ b/src/test/java/config/User.java
@@ -12,6 +12,7 @@ public enum User {
     FOI_USER("foi automated regression user", "Password1!", "FOI Regression (foiregressiont@test.com)"),
     MPAM_SUPERUSER("mpam super user", "Password1!", "MPAM Super User (mpamsuperuser@test.com)"),
     COMP_SUPERUSER("comp super user", "Password1!", "COMP Super User (compsuperuser@test.com)"),
+    FOI_SUPERUSER("foi super user", "Password1!", "FOI Super User (foisuperuser@test.com)"),
     WCS_TASKFORCE_USER("wcs taskforce user", "Password1!", "WCS Taskforce User (wcstaskforceuser@test.com)"),
     TEST_USER_1("test user 1", "Password1!", "Test User 1 (testuser1@test.com)"),
     CASEY("casey.prosser@ten10.com", "Password1!", "Casey Prosser (casey.prosser@ten10.com)"),

--- a/src/test/resources/features/foi/Superuser.feature
+++ b/src/test/resources/features/foi/Superuser.feature
@@ -1,0 +1,18 @@
+@Superuser @FOI
+Feature: Superuser
+
+  @ComplaintsRegression
+  Scenario: A FOI Admin User can complete the FOI workflow
+    Given I log in to "CS" as user "FOI_SUPERUSER"
+    When I create a "FOI" case and move it to "Soft Close"
+    Then the case should be at the "Soft Close" stage
+
+  @ComplaintsRegression
+  Scenario: A FOI Admin User can complete a stage whilst case is owned by another user
+    Given I log in to "CS" as user "FOI_USER"
+    And I create a single "FOI" case
+    And I switch to user "FOI_SUPERUSER"
+    And I load the current case
+    And I complete the "Case Creation" stage
+    Then the case should be moved to the "Allocation" stage
+    And I logout of the application


### PR DESCRIPTION
Added Superuser feature in FOI folder, with 2 scenarios testing the functionality from membership in FOI case admin team.
Scenarios are copy of similar feature for COMP and MPAM, so no new steps or methods were required, just added FOI_Superuser to User enum file.