### PR TITLE
HOCS-4238 Complaint Type doesnt change when COMP/COMP2 cases transferred

### DIFF
--- a/src/test/resources/features/complaints/CCH.feature
+++ b/src/test/resources/features/complaints/CCH.feature
@@ -12,20 +12,25 @@ Feature: CCH
     And I select the "Transfer to CCT" action at CCH
     Then the case should be moved to the "Service Triage" stage
     And the summary should display the owning team as "CCT Stage 1 Triage Team"
+    And the summary should display "Service" for "Complaint Type"
     And the read-only Case Details accordion should contain all case information entered during the "CCH" stage
 
+#    Expected failure. Defect HOCS-4238 raised.
   @ComplaintsWorkflow @ComplaintsRegression
   Scenario: User can transfer the case to Ex-Gratia
     And I select the "Transfer to Ex-Gratia" action at CCH
     Then the case should be moved to the "Ex-Gratia Triage" stage
     And the summary should display the owning team as "Ex-Gratia"
+    And the summary should display "Ex-Gratia" for "Complaint Type"
     And the read-only Case Details accordion should contain all case information entered during the "CCH" stage
 
+#    Expected failure. Defect HOCS-4238 raised.
   @ComplaintsWorkflow @ComplaintsRegression
   Scenario: User can transfer the case to Minor Misconduct
     And I select the "Transfer to Minor Misconduct" action at CCH
     Then the case should be moved to the "Minor Misconduct Triage" stage
     And the summary should display the owning team as "Minor Misconduct"
+    And the summary should display "Minor Misconduct" for "Complaint Type"
     And the read-only Case Details accordion should contain all case information entered during the "CCH" stage
 
 #    HOCS-3025


### PR DESCRIPTION
Added assertions for issue identified in Prod (gap in regression coverage). Expect scenarios to fail until issue is resolved (added comment to track this)