### PR TITLE
Updated Action case note assertions for new page elements and structure.

### DIFF
--- a/src/test/java/com/hocs/test/glue/decs/BaseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/BaseStepDefs.java
@@ -2,7 +2,6 @@ package com.hocs.test.glue.decs;
 
 import static jnr.posix.util.MethodName.getMethodName;
 import static net.serenitybdd.core.Serenity.pendingStep;
-import static net.serenitybdd.core.Serenity.sessionVariableCalled;
 import static net.serenitybdd.core.Serenity.setSessionVariable;
 
 import com.hocs.test.pages.decs.BasePage;
@@ -11,7 +10,6 @@ import com.hocs.test.pages.decs.PeopleTab;
 import com.hocs.test.pages.decs.SummaryTab;
 import com.hocs.test.pages.decs.TimelineTab;
 import com.hocs.test.pages.decs.CaseView;
-import com.hocs.test.pages.dcu.DataInput;
 import config.User;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
@@ -85,9 +83,7 @@ public class BaseStepDefs extends BasePage {
         dashboard.getCurrentCase();
         caseView.assertCaseCannotBeAllocated();
         summaryTab.assertThereIsNoActiveStage();
-        if (!wcsCase()) {
-            timelineTab.assertWCSCaseClosedNoteVisible();
-        }
+        timelineTab.assertCaseClosedNoteVisible();
         System.out.println("The case is closed");
     }
 

--- a/src/test/java/com/hocs/test/glue/decs/TimelineStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/TimelineStepDefs.java
@@ -164,9 +164,9 @@ public class TimelineStepDefs extends BasePage {
         timelineTab.assertAppealUpdatedNoteVisible();
     }
 
-    @And("an Interest Recorded note should be visible in the timeline for the interested party")
+    @And("an Interest Created note should be visible in the timeline for the interested party")
     public void anInterestCreatedNoteShouldBeVisibleInTheTimelineForTheSelectedAppealType() {
-        timelineTab.assertInterestRecordedNoteVisible();
+        timelineTab.assertInterestCreatedNoteVisible();
     }
 
     @And("an Interest Updated note should be visible in the timeline for the interested party")

--- a/src/test/java/com/hocs/test/pages/decs/BasePage.java
+++ b/src/test/java/com/hocs/test/pages/decs/BasePage.java
@@ -350,7 +350,7 @@ public class BasePage extends PageObject {
     }
 
     public String setCaseReferenceFromAssignedCase() {
-        headerCaption1.waitUntilVisible();
+        headerCaption1.waitUntilVisible().withTimeoutOf(Duration.ofSeconds(10));
         waitFor(ExpectedConditions.textToBePresentInElement(headerCaption1, sessionVariableCalled("caseType")))
                 .withTimeoutOf(Duration.ofSeconds(20));
         setSessionVariable("caseReference").to(headerCaption1.getText());

--- a/src/test/java/com/hocs/test/pages/decs/TimelineTab.java
+++ b/src/test/java/com/hocs/test/pages/decs/TimelineTab.java
@@ -9,6 +9,8 @@ import config.User;
 import net.serenitybdd.core.annotations.findby.FindBy;
 import net.serenitybdd.core.pages.WebElementFacade;
 import org.hamcrest.core.Is;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 public class TimelineTab extends BasePage {
 
@@ -75,17 +77,17 @@ public class TimelineTab extends BasePage {
     @FindBy(xpath = "//span[text()='Allocation note']/parent::p")
     public WebElementFacade allocationNoteContents;
 
-    @FindBy(xpath = "//span[text()='Appeal Created']/parent::p")
-    public WebElementFacade appealCreatedNoteContents;
+    @FindBy(xpath = "//strong[contains(text(),'Appeal Created')]")
+    public WebElementFacade appealCreatedNote;
 
-    @FindBy(xpath = "//span[text()='Appeal Updated']/parent::p")
-    public WebElementFacade appealUpdatedNoteContents;
+    @FindBy(xpath = "//strong[contains(text(),'Appeal Updated')]")
+    public WebElementFacade appealUpdatedNote;
 
-    @FindBy(xpath = "//span[text()='Interest Recorded']/parent::p")
-    public WebElementFacade interestRecordedNoteContents;
+    @FindBy(xpath = "//strong[contains(text(),'Interest Created')]")
+    public WebElementFacade interestCreatedNote;
 
-    @FindBy(xpath = "//span[text()='Interest Updated']/parent::p")
-    public WebElementFacade interestUpdatedNoteContents;
+    @FindBy(xpath = "//strong[contains(text(),'Interest Updated')]")
+    public WebElementFacade interestUpdatedNote;
 
     @FindBy(xpath = "//li//span[text()='Case withdrawn']/ancestor::p")
     public WebElementFacade caseWithdrawnNoteContents;
@@ -258,7 +260,7 @@ public class TimelineTab extends BasePage {
         assertThat(caseTransferReasonNoteContents.getText().contains(inputTransferReason), is(true));
     }
 
-    public void assertWCSCaseClosedNoteVisible() {
+    public void assertCaseClosedNoteVisible() {
         selectTimelineTab();
         caseClosedNote.shouldBeVisible();
     }
@@ -290,26 +292,35 @@ public class TimelineTab extends BasePage {
     public void assertAppealCreatedNoteVisible() {
         selectTimelineTab();
         String appealType = sessionVariableCalled("appealType");
-        assertThat(appealCreatedNoteContents.getText().contains(appealType), is(true));
+        assertThat(appealCreatedNote.getText().contains(appealType), is(true));
     }
 
     public void assertAppealUpdatedNoteVisible() {
         selectTimelineTab();
         String appealType = sessionVariableCalled("appealType");
-        assertThat(appealUpdatedNoteContents.getText().contains(appealType), is(true));
+        assertThat(appealUpdatedNote.getText().contains(appealType), is(true));
     }
 
-    public void assertInterestRecordedNoteVisible() {
+    public void assertInterestCreatedNoteVisible() {
         selectTimelineTab();
+        String typeOfInterest = sessionVariableCalled("typeOfInterest");
         String interestedParty = sessionVariableCalled("interestedParty");
         String detailsOfInterest = sessionVariableCalled("detailsOfInterest");
-        assertThat(interestRecordedNoteContents.getText().contains(interestedParty + ": " +detailsOfInterest), is(true));
+        WebElementFacade interestCreatedNote = findBy("//strong[text()='" + typeOfInterest + " Created: " + interestedParty + "']");
+        interestCreatedNote.shouldBeVisible();
+        WebElementFacade interestCreatedNoteContents = findBy("//strong[text()='" + typeOfInterest + " Created: " + interestedParty + "']/ancestor::p/following-sibling::p/p");
+        assertThat(interestCreatedNoteContents.getText().contains(detailsOfInterest), is(true));
     }
 
     public void assertInterestUpdatedNoteVisible() {
         selectTimelineTab();
+        String typeOfInterest = sessionVariableCalled("typeOfInterest");
         String interestedParty = sessionVariableCalled("interestedParty");
+        WebElementFacade interestUpdatedNote = findBy("//strong[text()='" + typeOfInterest + " Updated: " + interestedParty + "']");
+        interestUpdatedNote.shouldBeVisible();
         String detailsOfInterest = sessionVariableCalled("detailsOfInterest");
-        assertThat(interestUpdatedNoteContents.getText().contains(interestedParty + ": " +detailsOfInterest), is(true));
+        WebElementFacade interestUpdatedNoteContents = findBy("//strong[text()='" + typeOfInterest + " Updated: " + interestedParty + "']/ancestor"
+                + "::p/following-sibling::p/p");
+        assertThat(interestUpdatedNoteContents.getText().contains(detailsOfInterest), is(true));
     }
 }

--- a/src/test/java/com/hocs/test/pages/decs/Workstacks.java
+++ b/src/test/java/com/hocs/test/pages/decs/Workstacks.java
@@ -419,15 +419,14 @@ public class Workstacks extends BasePage {
     }
 
     public void waitForTopCaseToNotBeAllocated() {
-        boolean allocated = !getValueFromSpecifiedColumnForSpecifiedCase("Owner", getCurrentCaseReference()).isEmpty();
+        boolean allocated = !getOwnerOfTopCaseInWorkstack().isEmpty();
         int attempts = 0;
         while (allocated && attempts<20) {
-            String owner = getValueFromSpecifiedColumnForSpecifiedCase("Owner", getCurrentCaseReference());
+            String owner = getOwnerOfTopCaseInWorkstack();
             allocated = !owner.isEmpty();
             waitABit(500);
             attempts++;
         }
-        System.out.print(attempts);
     }
 
     // Assertions

--- a/src/test/java/com/hocs/test/pages/foi/ActionsTab.java
+++ b/src/test/java/com/hocs/test/pages/foi/ActionsTab.java
@@ -128,6 +128,7 @@ public class ActionsTab extends BasePage {
 
     public void selectSpecificTypeOfInterest(String typeOfInterest) {
         selectSpecificOptionFromDropdownWithHeading(typeOfInterest, "What type of interest do you want to record?");
+        setSessionVariable("typeOfInterest").to(typeOfInterest);
     }
 
     public void selectAInterestedParty() {

--- a/src/test/resources/features/foi/Actions.feature
+++ b/src/test/resources/features/foi/Actions.feature
@@ -56,7 +56,7 @@ Feature: Actions
     And I submit details of the interest the external party has in the case
     Then I should see a confirmation message stating that the external interest has been registered
     And the details of the interest should be visible in the actions tab
-    And an Interest Recorded note should be visible in the timeline for the interested party
+    And an Interest Created note should be visible in the timeline for the interested party
     When I update the registered interest
     Then I should see a confirmation message stating that the external interest has been updated
     And the updated details of the interest should be visible in the actions tab


### PR DESCRIPTION
Extended wait time for header check on case view, as was failing at WCS claim creation step.
Removed condition for checking for Case Closed note, as it appears to have been added to all cases. If timeline lag starts to cause scenarios failures we should consider removing/hiding this again.
Amended waitForTopCaseToNotBeAllocated to use the top cases reference instead of the current cases reference, as this was intermittently breaking a COMP search scenario when attempting to unallocate a random search result.