### PR TITLE
HOCS-4139 Dispatch

### DIFF
--- a/src/test/java/com/hocs/test/glue/decs/DocumentsStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/DocumentsStepDefs.java
@@ -68,11 +68,7 @@ public class DocumentsStepDefs extends BasePage {
 
     @When("I click add documents")
     public void iClickAddDocuments() {
-        if (documents.addDocumentLink.isVisible()) {
-            safeClickOn(documents.addDocumentLink);
-        } else if (documents.addDocumentsButton.isVisible()) {
-            safeClickOn(documents.addDocumentsButton);
-        }
+        documents.clickVisibleAddDocumentsLink();
     }
 
     @And("I choose the document type {string}")
@@ -130,12 +126,12 @@ public class DocumentsStepDefs extends BasePage {
 
     @And("I upload a {int}MB and a {int}MB file")
     public void iUploadTwoFilesOfSizes(int fileSize1, int fileSize2) {
-        iClickAddDocuments();
+        documents.clickVisibleAddDocumentsLink();
         documents.selectADocumentType();
         iUploadAFileThatIsMBInSize(fileSize1);
         documents.waitForFileToUpload(fileSize1);
         iClickManageDocuments();
-        iClickAddDocuments();
+        documents.clickVisibleAddDocumentsLink();
         documents.selectADocumentType();
         iUploadAFileThatIsMBInSize(fileSize2);
         documents.waitForFileToUpload(fileSize2);
@@ -159,8 +155,10 @@ public class DocumentsStepDefs extends BasePage {
 
     @And("I add a/an {string} type document to the case")
     public void iAddATypeDocumentToTheCase(String docType) {
+        waitForPageWithTitle("Dispatch");
         documents.addADocumentOfDocumentType(docType);
         iCanSeeTheFileInTheUploadedDocumentList(sessionVariableCalled("fileType"));
+        documents.assertDocumentIsUnderHeader(docType);
     }
 
     @And("I remove the {string} document")
@@ -193,7 +191,7 @@ public class DocumentsStepDefs extends BasePage {
 
     @And("I upload a file that fails to convert to PDF")
     public void iUploadAFileThatWillFailToConvertToPDF() {
-        safeClickOn(documents.addDocumentLink);
+        documents.clickVisibleAddDocumentsLink();
         documents.selectADocumentType();
         documents.uploadDocumentThatFailsConversion();
         clickTheButton("Add");

--- a/src/test/java/com/hocs/test/glue/to/DisptachStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/to/DisptachStepDefs.java
@@ -1,0 +1,26 @@
+package com.hocs.test.glue.to;
+
+import com.hocs.test.pages.decs.BasePage;
+import com.hocs.test.pages.decs.Documents;
+import com.hocs.test.pages.to.Dispatch;
+import io.cucumber.java.en.And;
+
+public class DisptachStepDefs extends BasePage {
+
+    Dispatch dispatch;
+
+    Documents documents;
+
+    @And("I enter the details of the dispatch")
+    public void iEnterTheDetailsOfTheDispatch() {
+        dispatch.enterDateOfDispatch();
+        dispatch.selectAFinalDispatchChannel();
+        documents.recordFinalResponseDocument();
+    }
+
+    @And("I confirm the case is completed")
+    public void iConfirmTheCaseIsCompleted() {
+        dispatch.selectTheAction("Complete case");
+        clickTheButton("Finish");
+    }
+}

--- a/src/test/java/com/hocs/test/pages/decs/BasePage.java
+++ b/src/test/java/com/hocs/test/pages/decs/BasePage.java
@@ -369,8 +369,14 @@ public class BasePage extends PageObject {
 
     public void safeClickOn(WebElementFacade webElementFacade) {
         webElementFacade.withTimeoutOf(Duration.ofSeconds(60)).waitUntilVisible().waitUntilClickable();
-        javascriptScrollToElem(webElementFacade);
-        webElementFacade.click();
+        try {
+            javascriptScrollToElem(webElementFacade);
+            webElementFacade.click();
+        } catch (StaleElementReferenceException e) {
+            waitABit(500);
+            javascriptScrollToElem(webElementFacade);
+            webElementFacade.click();
+        }
     }
 
     public void jsClickOn(WebElementFacade webElementFacade) {

--- a/src/test/java/com/hocs/test/pages/decs/Documents.java
+++ b/src/test/java/com/hocs/test/pages/decs/Documents.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.List;
 import net.serenitybdd.core.annotations.findby.FindBy;
 import net.serenitybdd.core.pages.WebElementFacade;
 import org.openqa.selenium.By;
@@ -21,9 +22,6 @@ public class Documents extends BasePage {
     @FindBy(xpath = "//a[text() = 'Manage Documents']")
     public WebElementFacade manageDocumentsLink;
 
-    @FindBy(xpath = "//a[text() = 'Add document']")
-    public WebElementFacade addDocumentLink;
-
     @FindBy(id = "add_document")
     public WebElementFacade addDocument;
 
@@ -35,9 +33,6 @@ public class Documents extends BasePage {
 
     @FindBy(xpath = "//a[@href = '#add_document-error']")
     public WebElementFacade addDocumentErrorMessage;
-
-    @FindBy(xpath = "//a[text()='document']")
-    public WebElementFacade addDocumentsButton;
 
     @FindBy(id = "document_type")
     public WebElementFacade documentTypeDropDown;
@@ -133,11 +128,7 @@ public class Documents extends BasePage {
     }
 
     public void addADocumentOfDocumentType(String docType) {
-        if (addDocumentsButton.isVisible()) {
-            safeClickOn(addDocumentsButton);
-        } else if (addDocumentLink.isVisible()) {
-            safeClickOn(addDocumentLink);
-        }
+        clickVisibleAddDocumentsLink();
         selectDocumentTypeByText(docType);
         uploadFileOfType("docx");
         safeClickOn(addButton);
@@ -145,12 +136,20 @@ public class Documents extends BasePage {
         waitABit(500);
     }
 
-    public void addADocumentOfFileType(String fileType) {
-        if (addDocumentsButton.isVisible()) {
-            safeClickOn(addDocumentsButton);
-        } else if (addDocumentLink.isVisible()) {
-            safeClickOn(addDocumentLink);
+    public void clickVisibleAddDocumentsLink() {
+        List<WebElementFacade> addDocumentLinks = findAll("//a[contains(text(),'Add') and contains(.,'document')]");
+        for ( WebElementFacade addDocumentLink : addDocumentLinks
+        ) {
+            if (addDocumentLink.isVisible()) {
+                safeClickOn(addDocumentLink);
+                break;
+            }
         }
+        waitForPageWithTitle("Add Documents");
+    }
+
+    public void addADocumentOfFileType(String fileType) {
+        clickVisibleAddDocumentsLink();
         selectADocumentType();
         uploadFileOfType(fileType);
         safeClickOn(addButton);
@@ -158,11 +157,7 @@ public class Documents extends BasePage {
     }
 
     public void addADocumentOfDocumentTypeAndFileType(String docType, String fileType) {
-        if (addDocumentsButton.isVisible()) {
-            safeClickOn(addDocumentsButton);
-        } else if (addDocumentLink.isVisible()) {
-            safeClickOn(addDocumentLink);
-        }
+        clickVisibleAddDocumentsLink();
         selectDocumentTypeByText(docType);
         uploadFileOfType(fileType);
         safeClickOn(addButton);
@@ -183,7 +178,7 @@ public class Documents extends BasePage {
     }
 
     public void clickRemoveLinkForFile(String fileIdentifier) {
-        addDocumentLink.waitUntilVisible();
+        waitForPageWithTitle("Manage Documents");
         WebElementFacade removeLink =
                 findBy("//td[contains(text(), '" + fileIdentifier
                         + "')]/following-sibling::td/a[contains(text(), 'Remove')]");
@@ -289,6 +284,14 @@ public class Documents extends BasePage {
         selectedPrimaryDraftDocument.waitUntilVisible();
         recordCaseData.addHeadingAndValueRecord(selectedPrimaryDraftHeading.getText(), selectedPrimaryDraftDocument.getText());
         setSessionVariable("primaryDraft").to(selectedPrimaryDraftDocument.getText());
+    }
+
+    public void recordFinalResponseDocument() {
+        WebElementFacade selectedPrimaryDraftDocument = findBy("//input[@name='FinalResponse'][@checked]/following-sibling::label");
+        WebElementFacade selectedPrimaryDraftHeading = findBy("//input[@name='FinalResponse'][@checked]/ancestor::fieldset//span");
+        selectedPrimaryDraftDocument.waitUntilVisible();
+        recordCaseData.addHeadingAndValueRecord(selectedPrimaryDraftHeading.getText(), selectedPrimaryDraftDocument.getText());
+        setSessionVariable("finalResponse").to(selectedPrimaryDraftDocument.getText());
     }
 
     public void assertThatPrimaryDraftIs(String fileName) {

--- a/src/test/java/com/hocs/test/pages/to/Dispatch.java
+++ b/src/test/java/com/hocs/test/pages/to/Dispatch.java
@@ -1,0 +1,21 @@
+package com.hocs.test.pages.to;
+
+import com.hocs.test.pages.decs.BasePage;
+import com.hocs.test.pages.decs.RecordCaseData;
+
+public class Dispatch extends BasePage {
+
+    RecordCaseData recordCaseData;
+
+    public void enterDateOfDispatch() {
+        recordCaseData.enterDateIntoDateFieldsWithHeading(getTodaysDate(), "Date the final response was dispatched");
+    }
+
+    public void selectAFinalDispatchChannel() {
+        recordCaseData.selectRandomRadioButtonFromGroupWithHeading("Final response channel");
+    }
+
+    public void selectTheAction(String action) {
+        selectSpecificRadioButtonFromGroupWithHeading(action, "Actions");
+    }
+}

--- a/src/test/resources/features/to/Dispatch.feature
+++ b/src/test/resources/features/to/Dispatch.feature
@@ -1,0 +1,21 @@
+@Dispatch @TO
+Feature: Dispatch
+
+  Background:
+    Given I am logged into "CS" as user "TO_USER"
+    And I get a "TO" case at the "Dispatch" stage
+
+  @TOWorkflow @TORegression
+  Scenario: As a Disptach user, I want to be able to enter the details of dispatch, so the case can be closed
+    When I add a "Final response" type document to the case
+    And I enter the details of the dispatch
+    And I confirm the case is completed
+    Then the case should be closed
+    And the read-only Case Details accordion should contain all case information entered during the "Dispatch" stage
+
+  @TORegression
+  Scenario: As a Dispatch user, I want to be able to save changes to the case, so corrections can be made
+    When I open the "Case Details" accordion section
+    And I change the channel the correspondence was received by
+    And I save the changes
+    Then the amended value for Channel Received should be saved to the case


### PR DESCRIPTION
Created scenarios, glue and page methods for TO Dispatch stage.
Added method Documents.recordFinalResponseDocument, so selected document value can be checked in standard accordion assertion.
Refactored the logic for finding the 'Add document'/'Add a document' link into a method in Documents.java, it not finds all matching links, then only click the currently visible one.
Added an extra wait and an assertion to iAddATypeDocumentToTheCase, to make it more robust.
Added a try/catch to BasePage.safeClickOn for handling instances of stale element exception.