### PR TITLE
HOCS-4134 Campaign

### DIFF
--- a/src/test/java/com/hocs/test/glue/dcu/DataInputStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/DataInputStepDefs.java
@@ -108,7 +108,7 @@ public class DataInputStepDefs extends BasePage {
     public void theCorrectCorrespondentIsRecordedAsTheCorrespondent() {
         dashboard.getCurrentCase();
         caseView.openOrCloseAccordionSection("Data Input");
-        caseView.assertExpectedValueIsVisibleInCaseDetailsAccordionForGivenHeading(sessionVariableCalled("primaryCorrespondent"), "Which is the "
+        caseView.assertExpectedValueIsVisibleInOpenCaseDetailsAccordionForGivenKey(sessionVariableCalled("primaryCorrespondent"), "Which is the "
                         + "primary correspondent?");
     }
 

--- a/src/test/java/com/hocs/test/glue/dcu/InitialDraftStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/InitialDraftStepDefs.java
@@ -88,7 +88,7 @@ public class InitialDraftStepDefs extends BasePage {
     @And("the case should (still be owned by)(be returned to) the drafting team")
     public void theCaseShouldStillBeOwnedByTheDraftingTeam() {
         openOrCloseAccordionSection("Markup");
-        String draftingTeam = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading("Initial Draft Team").get(0);
+        String draftingTeam = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenKey("Initial Draft Team").get(0);
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(draftingTeam, "Team");
     }
 
@@ -107,7 +107,7 @@ public class InitialDraftStepDefs extends BasePage {
     @And("the case should now be owned be the correct Private Office team")
     public void theCaseShouldNowBeOwnedBeThePrivateOfficeTeam() {
         openOrCloseAccordionSection("Markup");
-        String privateOfficeTeam = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading("Private Office Team").get(0);
+        String privateOfficeTeam = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenKey("Private Office Team").get(0);
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(privateOfficeTeam, "Team");
     }
 

--- a/src/test/java/com/hocs/test/glue/dcu/QAResponseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/dcu/QAResponseStepDefs.java
@@ -1,13 +1,10 @@
 package com.hocs.test.glue.dcu;
 
 import com.hocs.test.pages.decs.BasePage;
-import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.CaseView;
 import com.hocs.test.pages.decs.SummaryTab;
-import com.hocs.test.pages.decs.Workstacks;
 import com.hocs.test.pages.dcu.QAResponse;
 import io.cucumber.java.en.And;
-import io.cucumber.java.en.When;
 
 
 public class QAResponseStepDefs extends BasePage {
@@ -27,7 +24,7 @@ public class QAResponseStepDefs extends BasePage {
     @And("the case should( still)( be owned by)( be returned to) the Private Office team")
     public void theCaseShouldBeOwnedByThePrivateOfficeTeam() {
         openOrCloseAccordionSection("Markup");
-        String privateOfficeTeam = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading("Private Office Team").get(0);
+        String privateOfficeTeam = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenKey("Private Office Team").get(0);
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(privateOfficeTeam, "Team");
     }
 

--- a/src/test/java/com/hocs/test/glue/decs/DocumentsStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/DocumentsStepDefs.java
@@ -155,7 +155,6 @@ public class DocumentsStepDefs extends BasePage {
 
     @And("I add a/an {string} type document to the case")
     public void iAddATypeDocumentToTheCase(String docType) {
-        waitForPageWithTitle("Dispatch");
         documents.addADocumentOfDocumentType(docType);
         iCanSeeTheFileInTheUploadedDocumentList(sessionVariableCalled("fileType"));
         documents.assertDocumentIsUnderHeader(docType);

--- a/src/test/java/com/hocs/test/glue/decs/ProgressCaseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/ProgressCaseStepDefs.java
@@ -73,7 +73,7 @@ public class ProgressCaseStepDefs extends BasePage {
                 wcsProgressCase.completeTheWCSStageSoThatCaseMovesToTargetStage(stage,"Happy Path");
                 break;
             case "TO":
-                toProgressCase.completeTheTOStage(stage);
+                toProgressCase.completeTheTOStageSoThatCaseMovesToTargetStage(stage, "Happy Path");
                 break;
             default:
                 pendingStep(caseType + " is not defined within " + getMethodName());

--- a/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
@@ -148,6 +148,9 @@ public class SummaryTabStepDefs extends BasePage {
     @Then("the case should be moved to the correct Treat Official team for the new business area")
     public void theCaseShouldBeMovedToTheCorrectTreatOfficialTeamForTheNewBusinessArea() {
         waitABit(2000);
+        if (!caseView.currentCaseIsLoaded()) {
+            dashboard.loadCase(getCurrentCaseReference());
+        }
         String teamName = "Treat Official " + sessionVariableCalled("businessArea");
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(teamName, "Team");
     }
@@ -193,5 +196,10 @@ public class SummaryTabStepDefs extends BasePage {
     public void theAmendedValueForBusinessUnitShouldBeSavedToTheCase() {
         waitABit(2000);
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("businessUnit"),"Business Unit");
+    }
+
+    @And("the summary should contain the selected campaign")
+    public void theSummaryShouldContainTheSelectedCampaign() {
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("campaign"),"Campaign name");
     }
 }

--- a/src/test/java/com/hocs/test/glue/to/CampaignSteDefs.java
+++ b/src/test/java/com/hocs/test/glue/to/CampaignSteDefs.java
@@ -1,0 +1,44 @@
+package com.hocs.test.glue.to;
+
+import static net.serenitybdd.core.Serenity.sessionVariableCalled;
+import static net.serenitybdd.core.Serenity.setSessionVariable;
+
+import com.hocs.test.pages.decs.BasePage;
+import com.hocs.test.pages.decs.CaseView;
+import com.hocs.test.pages.to.Campaign;
+import io.cucumber.java.en.When;
+import org.openqa.selenium.Keys;
+import io.cucumber.java.en.And;
+
+public class CampaignSteDefs extends BasePage {
+
+    Campaign campaign;
+
+    CaseView caseView;
+
+    @And("I put the case into a {string}")
+    public void iPutTheCaseIntoACampaign(String campaignCampaign) {
+        campaign.selectTheAction("Put case into a " + campaignCampaign);
+        clickTheButton("Finish");
+        campaign.selectACampaign();
+        clickTheButton("Confirm");
+    }
+
+    @And("the Case Details accordion should contain the selected campaign")
+    public void theCaseDetailsAccordionShouldContainTheSelectedCampaign() {
+        openOrCloseAccordionSection("Campaign");
+        caseView.assertExpectedValueIsVisibleInOpenCaseDetailsAccordionForGivenKey(sessionVariableCalled("campaign"), "Campaign");
+    }
+
+    @When("I select to move the case to triage")
+    public void iSelectToMoveTheCaseToTriage() {
+        campaign.selectTheAction("Take out of Campaign, move to triage");
+        clickTheButton("Confirm");
+    }
+
+    @When("I select to move the case to draft")
+    public void iSelectToMoveTheCaseToDraft() {
+        campaign.selectTheAction("Take out of Campaign, move to draft");
+        clickTheButton("Confirm");
+    }
+}

--- a/src/test/java/com/hocs/test/pages/decs/BasePage.java
+++ b/src/test/java/com/hocs/test/pages/decs/BasePage.java
@@ -21,6 +21,7 @@ import net.thucydides.core.pages.PageObject;
 import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -610,6 +611,43 @@ public class BasePage extends PageObject {
         WebElementFacade checkbox =
                 findBy("//input[@type='checkbox']/following-sibling::label[text()=" + sanitiseXpathAttributeString(checkboxLabelText) + "]");
         safeClickOn(checkbox);
+    }
+
+    // Typeaheads
+
+    public String selectRandomOptionFromTypeaheadWithHeading(String headingText) {
+        WebElementFacade typeahead = findBy("//label[text()=" + sanitiseXpathAttributeString(headingText) + "]/following-sibling::div//input");
+        safeClickOn(typeahead);
+        waitABit(200);
+        boolean selectableOptionVisibleInTypeahead = false;
+        List<WebElementFacade> typeaheadOptions = null;
+        int attempts = 0;
+        while (!selectableOptionVisibleInTypeahead && attempts < 20) {
+            typeahead.clear();
+            typeahead.sendKeys(generateRandomStringOfLength(1));
+            waitABit(1000);
+            typeaheadOptions = findAll("//div[contains(@class,'option')]");
+            selectableOptionVisibleInTypeahead = typeaheadOptions.size() > 1;
+            attempts++;
+        }
+        Random random = new Random();
+        WebElementFacade optionToSelect = typeaheadOptions.get(random.nextInt(typeaheadOptions.size()));
+        safeClickOn(optionToSelect);
+        waitABit(500);
+        WebElementFacade selectedOption = findBy("//div[contains(@class,'govuk-typeahead__single-value')]");
+        return selectedOption.getText();
+    }
+
+    public String selectSpecificOptionFromTypeaheadWithHeading(String optionText, String headingText) {
+        WebElementFacade typeahead = findBy("//label[text()='" + sanitiseXpathAttributeString(headingText) + "']/following-sibling::div//input");
+        safeClickOn(typeahead);
+        waitABit(200);
+        typeahead.sendKeys(optionText);
+        waitABit(500);
+        typeahead.sendKeys(Keys.RETURN);
+        waitABit(500);
+        WebElementFacade selectedOption = findBy("//div[contains(@class,'govuk-typeahead__single-value')]");
+        return selectedOption.getText();
     }
 
     // Other methods

--- a/src/test/java/com/hocs/test/pages/decs/CaseView.java
+++ b/src/test/java/com/hocs/test/pages/decs/CaseView.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import net.serenitybdd.core.annotations.findby.FindBy;
 import net.serenitybdd.core.pages.WebElementFacade;
+import org.junit.Assert;
 import org.openqa.selenium.ElementNotVisibleException;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -45,7 +46,7 @@ public class CaseView extends BasePage {
         return allocateToMeLink.isCurrentlyVisible();
     }
 
-    public List<String> getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading(String heading) {
+    public List<String> getValuesFromOpenCaseDetailsAccordionSectionForGivenKey(String heading) {
         List<WebElementFacade> valuesForMatchingHeadings = findAll("//Strong[contains(text(),'" + heading + "')]/parent::span");
         List<String> valuesText = new ArrayList<>();
         for (WebElementFacade value : valuesForMatchingHeadings) {
@@ -110,7 +111,17 @@ public class CaseView extends BasePage {
         return false;
     }
 
-    public void assertExpectedValueIsVisibleInCaseDetailsAccordionForGivenHeading(String expectedValue, String heading) {
-        assertThat(expectedValue.equals(getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading(heading).get(0)), is(true));
+    public void assertExpectedValueIsVisibleInOpenCaseDetailsAccordionForGivenKey(String expectedAccordionValue, String accordionKey) {
+        List<String> visibleDisplayValues = getValuesFromOpenCaseDetailsAccordionSectionForGivenKey(accordionKey);
+        boolean expectedValueIsDisplayed = false;
+        for (String visibleDisplayValue : visibleDisplayValues) {
+            if (visibleDisplayValue.contains(expectedAccordionValue)) {
+                expectedValueIsDisplayed = true;
+                break;
+            }
+        }
+        if (!expectedValueIsDisplayed) {
+            Assert.fail("'" + accordionKey + ": " + expectedAccordionValue + "' is not visible in accordion");
+        }
     }
 }

--- a/src/test/java/com/hocs/test/pages/decs/Correspondents.java
+++ b/src/test/java/com/hocs/test/pages/decs/Correspondents.java
@@ -66,9 +66,6 @@ public class Correspondents extends BasePage {
     @FindBy(xpath = "//input[@name='Correspondents'][not(@checked)]/following-sibling::label")
     private WebElementFacade secondaryCorrespondentName;
 
-    @FindBy(xpath = "//div[contains(@class,'govuk-typeahead__single-value')]")
-    public WebElementFacade memberOfParliamentName;
-
     @FindBy(xpath = "//a[text()='The correspondent type must be provided']")
     public WebElementFacade correspondentTypeMustBeProvidedErrorMessage;
 
@@ -236,30 +233,14 @@ public class Correspondents extends BasePage {
     }
 
     public void selectSpecificMemberOfParliament(String member) {
-        safeClickOn(selectMPDropdown);
-        waitABit(200);
-        selectMPDropdown.sendKeys(member);
-        waitABit(1000);
-        selectMPDropdown.sendKeys(Keys.RETURN);
-        setSessionVariable("correspondentFullName").to(memberOfParliamentName.getText());
+        String correspondentFullName = selectSpecificOptionFromTypeaheadWithHeading(member, "Member");
+        setSessionVariable("correspondentFullName").to(correspondentFullName);
         clickAddButton();
     }
 
     public void selectRandomMemberOfParliament() {
-        safeClickOn(selectMPDropdown);
-        waitABit(200);
-        boolean selectableMemberVisible = false;
-        List<WebElementFacade> memberOptions = null;
-        while (!selectableMemberVisible) {
-            selectMPDropdown.clear();
-            selectMPDropdown.sendKeys(generateRandomStringOfLength(1));
-            waitABit(1000);
-            memberOptions = findAll("//div[contains(@class,'option')]");
-            selectableMemberVisible = memberOptions.size() > 1;
-        }
-        Random random = new Random();
-        safeClickOn(memberOptions.get(random.nextInt(memberOptions.size())));
-        setSessionVariable("correspondentFullName").to(memberOfParliamentName.getText());
+        String correspondentFullName = selectRandomOptionFromTypeaheadWithHeading("Member");
+        setSessionVariable("correspondentFullName").to(correspondentFullName);
         clickAddButton();
     }
 

--- a/src/test/java/com/hocs/test/pages/decs/RecordCaseData.java
+++ b/src/test/java/com/hocs/test/pages/decs/RecordCaseData.java
@@ -3,7 +3,6 @@ package com.hocs.test.pages.decs;
 import java.util.HashMap;
 import java.util.List;
 import net.serenitybdd.core.pages.WebElementFacade;
-import org.junit.Assert;
 
 public class RecordCaseData extends BasePage{
 
@@ -97,6 +96,22 @@ public class RecordCaseData extends BasePage{
         addValueRecord(checkboxLabelText);
     }
 
+    // Typeaheads
+
+    public String selectRandomOptionFromTypeaheadWithHeading(String headingText) {
+        String optionText = super.selectRandomOptionFromTypeaheadWithHeading(headingText);
+        addHeadingAndValueRecord(headingText,optionText);
+        return optionText;
+    }
+
+    public String selectSpecificOptionFromTypeaheadWithHeading(String optionText, String headingText) {
+        String selectedOptionText = super.selectSpecificOptionFromTypeaheadWithHeading(optionText, headingText);
+        addHeadingAndValueRecord(headingText, optionText);
+        return selectedOptionText;
+    }
+
+    // Other methods
+
     public void addHeadingAndValueRecord(String heading, String value) {
         dataRecords.put(heading, value);
     }
@@ -107,18 +122,9 @@ public class RecordCaseData extends BasePage{
 
     public void assertAllRecordedCaseDataIsDisplayedInTheReadOnlyAccordionSection() {
         for(HashMap.Entry<String, String> entry : dataRecords.entrySet()) {
-            List<String> visibleDisplayValues = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading(entry.getKey());
-            String expectedDisplayValue = entry.getValue();
-            boolean expectedValueIsDisplayed = false;
-            for (String visibleDisplayValue : visibleDisplayValues) {
-                if (visibleDisplayValue.contains(expectedDisplayValue)) {
-                    expectedValueIsDisplayed = true;
-                    break;
-                }
-            }
-            if (!expectedValueIsDisplayed) {
-                Assert.fail("'" + entry.getKey() + ": " + expectedDisplayValue + "' is not visible in accordion");
-            }
+            String accordionKey = entry.getKey();
+            String expectedAccordionValue = entry.getValue();
+            caseView.assertExpectedValueIsVisibleInOpenCaseDetailsAccordionForGivenKey(expectedAccordionValue, accordionKey);
         }
     }
 

--- a/src/test/java/com/hocs/test/pages/decs/Search.java
+++ b/src/test/java/com/hocs/test/pages/decs/Search.java
@@ -697,7 +697,7 @@ public class Search extends BasePage {
                     workstacks.selectSpecificCaseReferenceLink(randomSearchResult);
                 }
                 openOrCloseAccordionSection("Registration");
-                displayedValue = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading("Date of Birth").get(0);
+                displayedValue = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenKey("Date of Birth").get(0);
                 expectedValue = sessionVariableCalled("searchComplainantDateOfBirth");
                 break;
             case "CASE REFERENCE":
@@ -756,7 +756,7 @@ public class Search extends BasePage {
                     workstacks.selectSpecificCaseReferenceLink(randomSearchResult);
                 }
                 openOrCloseAccordionSection("Case Registration");
-                displayedValue = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenHeading("Date of Birth").get(0);
+                displayedValue = caseView.getValuesFromOpenCaseDetailsAccordionSectionForGivenKey("Date of Birth").get(0);
                 expectedValue = sessionVariableCalled("searchComplainantDateOfBirth");
                 break;
             case "CASE REFERENCE":

--- a/src/test/java/com/hocs/test/pages/mpam/Campaign.java
+++ b/src/test/java/com/hocs/test/pages/mpam/Campaign.java
@@ -32,10 +32,8 @@ public class Campaign extends BasePage {
     public void moveCaseFromAStageToCampaign(String campaign) {
         safeClickOn(putCaseIntoCampaignRadioButton);
         safeClickOn(confirmButton);
-        safeClickOn(campaignSelectionTypeahead);
-        campaignSelectionTypeahead.sendKeys(campaign);
-        setSessionVariable("campaign").to(campaign);
-        campaignSelectionTypeahead.sendKeys(Keys.RETURN);
+        String selectedCampaign = selectSpecificOptionFromTypeaheadWithHeading(campaign, "Campaign");
+        setSessionVariable("campaign").to(selectedCampaign);
         safeClickOn(confirmButton);
     }
 

--- a/src/test/java/com/hocs/test/pages/to/Campaign.java
+++ b/src/test/java/com/hocs/test/pages/to/Campaign.java
@@ -1,0 +1,22 @@
+package com.hocs.test.pages.to;
+
+import static net.serenitybdd.core.Serenity.setSessionVariable;
+
+import com.hocs.test.pages.decs.BasePage;
+import java.util.List;
+import java.util.Random;
+import net.serenitybdd.core.pages.WebElementFacade;
+import org.openqa.selenium.Keys;
+
+public class Campaign extends BasePage {
+
+    public void selectTheAction(String action) {
+        selectSpecificRadioButtonFromGroupWithHeading(action, "Actions");
+    }
+
+    public void selectACampaign() {
+        waitForPageWithTitle("Specify campaign name");
+        String selectedCampaign = selectRandomOptionFromTypeaheadWithHeading("Campaign");
+        setSessionVariable("campaign").to(selectedCampaign);
+    }
+}

--- a/src/test/resources/features/to/Campaign.feature
+++ b/src/test/resources/features/to/Campaign.feature
@@ -1,0 +1,25 @@
+@Campaign @TO
+Feature: Campaign
+
+  Background:
+    Given I am logged into "CS" as user "TO_USER"
+    And I get a "TO" case at "Campaign" stage
+
+
+  @TORegression
+  Scenario:  As a Campaign user, I want to be able to return the case to Triage, so the case can progress
+    When I select to move the case to triage
+    Then the case should be returned to the "Triage" stage
+    And the case should still be owned by the correct Treat Official team for the selected business area
+
+  @TORegression
+  Scenario:  As a Campaign user, I want to be able to send the case to Draft, so the case can progress
+    When I select to move the case to draft
+    Then the case should be moved to the "Draft" stage
+    And the case should still be owned by the correct Treat Official team for the selected business area
+
+  @TORegression
+  Scenario:  As a Campaign user, I want to be able to change the business area of the case, so that the correct team can casework it
+    When I open the "Case Details" accordion section
+    And I change the Business Area of the case
+    Then the case should be moved to the correct Treat Official team for the new business area

--- a/src/test/resources/features/to/Dispatch.feature
+++ b/src/test/resources/features/to/Dispatch.feature
@@ -19,3 +19,13 @@ Feature: Dispatch
     And I change the channel the correspondence was received by
     And I save the changes
     Then the amended value for Channel Received should be saved to the case
+
+  @TOWorkflow @TORegression
+  Scenario: As a Dispatch user, I want to be able to put a case into a campaign, so it can be answered along with other cases from that campaign
+    When I add a "Final response" type document to the case
+    And I enter the details of the dispatch
+    And I put the case into a "campaign"
+    Then the case should be moved to the "Campaign" stage
+    And the case should still be owned by the correct Treat Official team for the selected business area
+    And the Case Details accordion should contain the selected campaign
+    And the summary should contain the selected campaign

--- a/src/test/resources/features/to/Draft.feature
+++ b/src/test/resources/features/to/Draft.feature
@@ -29,6 +29,15 @@ Feature: Draft
     Then the case should be moved to the "Triage" stage
     And the case should still be owned by the correct Treat Official team for the selected business area
 
+  @TOWorkflow @TORegression
+  Scenario: As a Draft user, I want to be able to put a case into a campaign, so it can be answered along with other cases from that campaign
+    When I add an "Initial Draft" type document to the case
+    And I put the case into a "Campaign"
+    Then the case should be moved to the "Campaign" stage
+    And the case should still be owned by the correct Treat Official team for the selected business area
+    And the Case Details accordion should contain the selected campaign
+    And the summary should contain the selected campaign
+
   @TORegression
   Scenario:  As a Draft user, I want to be able to change the business area of the case, so that the correct team can casework it
     When I open the "Case Details" accordion section

--- a/src/test/resources/features/to/QA.feature
+++ b/src/test/resources/features/to/QA.feature
@@ -30,6 +30,14 @@ Feature: QA
     And the read-only Case Details accordion should contain all case information entered during the "QA" stage
     And a Rejection note should be visible in the timeline showing the submitted reason for the return of the case
 
+  @TOWorkflow @TORegression
+  Scenario: As a QA user, I want to be able to put a case into a campaign, so it can be answered along with other cases from that campaign
+    And I put the case into a "campaign"
+    Then the case should be moved to the "Campaign" stage
+    And the case should still be owned by the correct Treat Official team for the selected business area
+    And the Case Details accordion should contain the selected campaign
+    And the summary should contain the selected campaign
+
   @TORegression
   Scenario: As a QA user, I want to be able to save changes to the case, so corrections can be made
     When I open the "Case Details" accordion section

--- a/src/test/resources/features/to/Triage.feature
+++ b/src/test/resources/features/to/Triage.feature
@@ -16,6 +16,16 @@ Feature: Triage
     And the read-only Case Details accordion should contain all case information entered during the "Triage" stage
     And the summary should contain the Enquiry Subject, Enquiry Reason and Business Unit
 
+  @TOWorkflow @TORegression
+  Scenario: As a Triage user, I want to be able to put a case into a campaign, so it can be answered along with other cases from that campaign
+    When I set an Enquiry Subject and Reason
+    And I select a Business Unit Type and corresponding Business Unit
+    And I put the case into a "campaign"
+    Then the case should be moved to the "Campaign" stage
+    And the case should still be owned by the correct Treat Official team for the selected business area
+    And the Case Details accordion should contain the selected campaign
+    And the summary should contain the selected campaign
+
   @TORegression
   Scenario:  As a Triage user, I want to be able to change the business area of the case, so that the correct team can casework it
     When I open the "Case Details" accordion section


### PR DESCRIPTION
Added scenarios, glue and methods for TO Campaign stage.
Added typeahead helper methods into BasePage, and implemented them where we had custom interactions with typeaheads in other pages.
Refactored the Case Details accordion key-and-value-visible assertion from RecordCaseData to CaseView, so it can be used in other assertions/steps.
Amended the 'complete the stage' method in TOProgressCase to take a target case so we can direct cases down non-happy-paths.