### PR TITLE
HOCS-4482 Add rejection reason note page at TO Draft

### DIFF
--- a/src/test/java/com/hocs/test/glue/to/DraftStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/to/DraftStepDefs.java
@@ -29,7 +29,7 @@ public class DraftStepDefs extends BasePage {
         clickTheButton("Finish");
     }
 
-    @When("I return the case to Triage")
+    @When("I select to return the TO case to Triage")
     public void iReturnTheCaseToTriage() {
         selectTheStageAction("Return to Triage");
         clickTheButton("Finish");
@@ -40,5 +40,11 @@ public class DraftStepDefs extends BasePage {
         draft.selectADifferentBusinessUnitType();
         waitABit(500);
         triage.selectABusinessUnit();
+    }
+
+    @And("I submit a reason to return the case to Triage")
+    public void iSubmitAReasonToReturnTheCaseToTriage() {
+        draft.enterReasonToReturnCasetoTriage();
+        clickTheButton("Continue");
     }
 }

--- a/src/test/java/com/hocs/test/pages/to/Draft.java
+++ b/src/test/java/com/hocs/test/pages/to/Draft.java
@@ -3,11 +3,19 @@ package com.hocs.test.pages.to;
 import static net.serenitybdd.core.Serenity.setSessionVariable;
 
 import com.hocs.test.pages.decs.BasePage;
+import com.hocs.test.pages.decs.RecordCaseData;
 
 public class Draft extends BasePage {
+
+    RecordCaseData recordCaseData;
 
     public void selectADifferentBusinessUnitType() {
         String newBusinessUnitType = selectDifferentOptionFromDropdownWithHeading("Business Unit Type");
         setSessionVariable("businessUnitType").to(newBusinessUnitType);
+    }
+
+    public void enterReasonToReturnCasetoTriage() {
+        String rejectionReason = recordCaseData.enterTextIntoTextAreaWithHeading("Why should this case be returned to Triage?");
+        setSessionVariable("rejectionReason").to(rejectionReason);
     }
 }

--- a/src/test/resources/features/to/Draft.feature
+++ b/src/test/resources/features/to/Draft.feature
@@ -25,9 +25,12 @@ Feature: Draft
 
   @TOWorkflow @TORegression
   Scenario: As a Draft user, I want to be able to return a case to Triage, so corrections can be made
-    When I return the case to Triage
+    When I select to return the TO case to Triage
+    And I submit a reason to return the case to Triage
     Then the case should be moved to the "Triage" stage
     And the case should still be owned by the correct Treat Official team for the selected business area
+    And the read-only Case Details accordion should contain all case information entered during the "Draft" stage
+    And a Rejection note should be visible in the timeline showing the submitted reason for the return of the case
 
   @TOWorkflow @TORegression
   Scenario: As a Draft user, I want to be able to put a case into a campaign, so it can be answered along with other cases from that campaign


### PR DESCRIPTION
Added step for entering rejection reason for returning a TO case from Draft to Triage and assertions for accordion and timeline visibility of submitted reason.