### PR TITLE
BF Register Interest action and removing TO MP Recipient example.

### DIFF
--- a/src/test/java/com/hocs/test/glue/decs/CaseDataStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/CaseDataStepDefs.java
@@ -1,5 +1,7 @@
 package com.hocs.test.glue.decs;
 
+import static net.serenitybdd.core.Serenity.sessionVariableCalled;
+
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.RecordCaseData;
@@ -29,6 +31,12 @@ public class CaseDataStepDefs extends BasePage {
             workstacks.selectSpecificCaseReferenceLink(getCurrentCaseReference());
         }
         openOrCloseAccordionSection(stageName);
+        recordCaseData.assertAllRecordedCaseDataIsDisplayedInTheReadOnlyAccordionSection();
+    }
+
+    @And("the closure reason and details should be visible in the Case Details accordion")
+    public void theClosureReasonAndDetailsShouldBeVisibleInTheCaseDetailsAccordion() {
+        openOrCloseAccordionSection("Early Closure");
         recordCaseData.assertAllRecordedCaseDataIsDisplayedInTheReadOnlyAccordionSection();
     }
 }

--- a/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
@@ -157,54 +157,50 @@ public class SummaryTabStepDefs extends BasePage {
 
     @And("the summary should contain the Business Area, Channel Received and Primary Correspondents details")
     public void theSummaryShouldContainTheBusinessAreaChannelReceivedAddresseeAndPrimaryCorrespondent() {
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("businessArea"),"Business Area");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("channelReceived"),"Channel Received");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentFullName"),"Primary correspondent");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentOrganisation"),"Primary correspondent");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentBuilding"),"Primary correspondent");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentStreet"),"Primary correspondent");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentTownOrCity"),"Primary correspondent");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentPostcode"),"Primary correspondent");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentCountry"),"Primary correspondent");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentTelephoneNumber"),"Primary correspondent");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentEmail"),"Primary correspondent");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentReference"),"Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("businessArea"), "Business Area");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("channelReceived"), "Channel Received");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentFullName"), "Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentOrganisation"), "Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentBuilding"), "Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentStreet"), "Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentTownOrCity"), "Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentPostcode"), "Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentCountry"), "Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentTelephoneNumber"), "Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentEmail"), "Primary correspondent");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("correspondentReference"), "Primary correspondent");
     }
 
-    @And("the summary should contain the {string} recipient")
-    public void theSummaryShouldContainTheRecipient(String recipientType) {
-        if (recipientType.equalsIgnoreCase("MEMBER")) {
-            summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("recipient"),"Recipient (Member of Parliament)");
-        } else {
-            summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("recipient"),"Recipient");
-        }
+    @And("the summary should contain the Recipient")
+    public void theSummaryShouldContainTheRecipient() {
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("recipient"), "Recipient");
     }
 
     @And("the summary should contain the Enquiry Subject, Enquiry Reason and Business Unit")
     public void theSummaryShouldContainTheEnquiryReasonAndEnquirySubjectAndBusinessUnit() {
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("enquirySubject"),"Enquiry Subject");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("enquiryReason"),"Enquiry Reason");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("businessUnit"),"Business Unit");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("enquirySubject"), "Enquiry Subject");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("enquiryReason"), "Enquiry Reason");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("businessUnit"), "Business Unit");
     }
 
     @Then("the amended value for Channel Received should be saved to the case")
     public void theAmendedValueForChannelReceivedShouldBeSavedToTheCase() {
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("channelReceived"),"Channel Received");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("channelReceived"), "Channel Received");
     }
 
     @Then("the amended value for Business Unit Type and Business Unit should be saved to the case")
     public void theAmendedValueForBusinessUnitShouldBeSavedToTheCase() {
         waitABit(2000);
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("businessUnit"),"Business Unit");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("businessUnit"), "Business Unit");
     }
 
     @And("the summary should contain the selected/new campaign")
     public void theSummaryShouldContainTheSelectedCampaign() {
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("campaign"),"Campaign name");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("campaign"), "Campaign name");
     }
 
     @And("the summary should contain the selected/new stop list")
     public void theSummaryShouldContainTheSelectedStopList() {
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("stopList"),"Stop List name");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("stopList"), "Stop List name");
     }
 }

--- a/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
@@ -203,4 +203,9 @@ public class SummaryTabStepDefs extends BasePage {
     public void theSummaryShouldContainTheSelectedStopList() {
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("stopList"), "Stop List name");
     }
+
+    @And("the closure reason and details should be visible in the Summary tab")
+    public void theClosureReasonAndDetailsShouldBeVisibleInTheSummaryTab() {
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("closureReason"), "Why should this case be closed?");
+    }
 }

--- a/src/test/java/com/hocs/test/glue/decs/TimelineStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/TimelineStepDefs.java
@@ -119,6 +119,12 @@ public class TimelineStepDefs extends BasePage {
         timelineTab.assertCaseNoteWithTitleContainsText("Case closure note", closureReason);
     }
 
+    @And("a Case closure note should be visible in the timeline showing the submitted supporting details for closing the case")
+    public void aCaseClosureNoteShouldBeVisibleInTheTimelineShowingTheSupportingDetailsForClosingTheCase() {
+        String closureDetails = sessionVariableCalled("closureDetails");
+        timelineTab.assertCaseNoteWithTitleContainsText("Case closure note", closureDetails);
+    }
+
     @And("a Details of follow up note should be visible in the timeline showing the submitted details of the required action")
     public void aDetailsOfFollowUpNoteShouldBeVisibleInTheTimelineShowingTheSubmittedDetailsOfTheRequiredAction() {
         String followUpDetails = sessionVariableCalled("followUpDetails");

--- a/src/test/java/com/hocs/test/glue/foi/ActionsTabStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/foi/ActionsTabStepDefs.java
@@ -130,7 +130,7 @@ public class ActionsTabStepDefs extends BasePage {
     @And("I submit details of the interest the external party has in the case")
     public void iSubmitDetailsOfTheInterestTheExternalPartyHasInTheCase() {
         actionsTab.selectSpecificTypeOfInterest("External Interest");
-        actionsTab.selectAInterestedParty();
+        actionsTab.selectAnInterestedParty();
         actionsTab.enterDetailsOfInterest("Test Details of Interest");
         clickTheButton("Add");
     }

--- a/src/test/java/com/hocs/test/glue/to/DataInputStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/to/DataInputStepDefs.java
@@ -26,17 +26,10 @@ public class DataInputStepDefs extends BasePage {
         clickTheButton("Continue");
     }
 
-    @When("I add a {string} recipient")
-    public void iAddARecipientTypeRecipient(String recipientType) {
+    @When("I add a Recipient to the case")
+    public void iAddARecipientTypeRecipient() {
         dataInput.selectWhetherToAddRecipient("Yes");
-        clickTheButton("Continue");
-        if (recipientType.equalsIgnoreCase("MEMBER")) {
-            dataInput.selectIfRecipientIsMember("Yes");
-            dataInput.selectAMemberRecipient();
-        } else {
-            dataInput.selectIfRecipientIsMember("No");
-            dataInput.selectANonMemberRecipient();
-        }
+        dataInput.selectARecipient();
         clickTheButton("Continue");
     }
 }

--- a/src/test/java/com/hocs/test/glue/to/TriageStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/to/TriageStepDefs.java
@@ -48,5 +48,22 @@ public class TriageStepDefs extends BasePage {
         selectTheStageAction("Save changes");
         clickTheButton("Finish");
     }
+
+    @When("I select to close the Treat Official case")
+    public void iSelectToCloseTheTreatOfficialCase() {
+        selectTheStageAction("Close case");
+        clickTheButton("Finish");
+    }
+
+    @And("I select a reason to close the case")
+    public void iSelectAReasonToCloseTheCase() {
+        triage.selectAClosureReason();
+    }
+
+    @And("I submit supporting details for the closure")
+    public void iSubmitSupportingDetailsForTheClosure() {
+        triage.enterClosureDetails();
+        clickTheButton("Confirm");
+    }
 }
 

--- a/src/test/java/com/hocs/test/pages/foi/ActionsTab.java
+++ b/src/test/java/com/hocs/test/pages/foi/ActionsTab.java
@@ -131,7 +131,7 @@ public class ActionsTab extends BasePage {
         setSessionVariable("typeOfInterest").to(typeOfInterest);
     }
 
-    public void selectAInterestedParty() {
+    public void selectAnInterestedParty() {
         String interestedParty = selectRandomOptionFromDropdownWithHeading("Interested party");
         setSessionVariable("interestedParty").to(interestedParty);
     }

--- a/src/test/java/com/hocs/test/pages/to/DataInput.java
+++ b/src/test/java/com/hocs/test/pages/to/DataInput.java
@@ -32,29 +32,7 @@ public class DataInput extends BasePage {
         selectSpecificRadioButtonFromGroupWithHeading(yesNo, "Do you wish to add a Recipient?");
     }
 
-    public void selectIfRecipientIsMember(String yesNo) {
-        recordCaseData.selectSpecificRadioButtonFromGroupWithHeading(yesNo, "Is the recipient a Member of Parliament?");
-    }
-
-    public void selectAMemberRecipient() {
-        safeClickOn(recipientTypeahead);
-        waitABit(200);
-        boolean selectableMemberVisible = false;
-        List<WebElementFacade> memberOptions = null;
-        while (!selectableMemberVisible) {
-            recipientTypeahead.clear();
-            recipientTypeahead.sendKeys(generateRandomStringOfLength(1));
-            waitABit(1000);
-            memberOptions = findAll("//div[contains(@class,'option')]");
-            selectableMemberVisible = memberOptions.size() > 1;
-        }
-        Random random = new Random();
-        safeClickOn(memberOptions.get(random.nextInt(memberOptions.size())));
-        setSessionVariable("recipient").to(selectedMemberRecipient.getText());
-        recordCaseData.addHeadingAndValueRecord("Recipient (Member of Parliament)", selectedMemberRecipient.getText());
-    }
-
-    public void selectANonMemberRecipient() {
+    public void selectARecipient() {
         String recipient = recordCaseData.selectRandomOptionFromDropdownWithHeading("Recipient");
         setSessionVariable("recipient").to(recipient);
     }

--- a/src/test/java/com/hocs/test/pages/to/Triage.java
+++ b/src/test/java/com/hocs/test/pages/to/Triage.java
@@ -49,4 +49,14 @@ public class Triage extends BasePage {
         String newChannelReceived = selectDifferentRadioButtonFromGroupWithHeading("Channel Received");
         setSessionVariable("channelReceived").to(newChannelReceived);
     }
+
+    public void selectAClosureReason() {
+        String closureReason = recordCaseData.selectRandomRadioButtonFromGroupWithHeading("Why should this case be closed?");
+        setSessionVariable("closureReason").to(closureReason);
+    }
+
+    public void enterClosureDetails() {
+        String closureDetails = recordCaseData.enterTextIntoTextAreaWithHeading("Please enter a details of why the case is being closed");
+        setSessionVariable("closureDetails").to(closureDetails);
+    }
 }

--- a/src/test/resources/features/complaints/Actions.feature
+++ b/src/test/resources/features/complaints/Actions.feature
@@ -1,0 +1,20 @@
+@ComplaintsActions @Complaints
+Feature: Actions
+
+  Background:
+    Given I am logged into "CS" as user "BF_USER"
+
+#    HOCS-4395, HOCS-4396, HOCS-5437
+  @ComplaintsRegression
+  Scenario: User is able to add and update a Registered Interest in a Border Force Complaints case
+    And I create a single "BF" case
+    And I view the actions tab of the case
+    When I select to record an interest in the case
+    And I submit details of the interest the external party has in the case
+    Then I should see a confirmation message stating that the external interest has been registered
+    And the details of the interest should be visible in the actions tab
+    And an Interest Created log should be visible in the timeline for the interested party
+    When I update the registered interest
+    Then I should see a confirmation message stating that the external interest has been updated
+    And the updated details of the interest should be visible in the actions tab
+    And an Interest Updated log should be visible in the timeline for the interested party

--- a/src/test/resources/features/to/DataInput.feature
+++ b/src/test/resources/features/to/DataInput.feature
@@ -20,16 +20,12 @@ Feature: Data Input
 
 #    Expected failure. Defect HOCS-4353 raised.
   @TOWorkflow @TORegression
-  Scenario Outline: As a Data Input user, I want to be able to enter th intended recipient, so the reply can be correctly personalised
+  Scenario: As a Data Input user, I want to be able to enter th intended recipient, so the reply can be correctly personalised
     And I select which business area the correspondence is for
     And I select which channel the correspondence was received by
     And I add a "Third Party Representative" correspondent
     And I confirm the primary correspondent
-    When I add a "<recipientType>" recipient
+    When I add a Recipient to the case
     Then the case should be moved to the "Triage" stage
-    And the summary should contain the "<recipientType>" recipient
+    And the summary should contain the Recipient
     And the read-only Case Details accordion should contain all case information entered during the "Data Input" stage
-    Examples:
-      | recipientType |
-      | Member        |
-      | Non-member    |

--- a/src/test/resources/features/to/Draft.feature
+++ b/src/test/resources/features/to/Draft.feature
@@ -63,4 +63,14 @@ Feature: Draft
     And I save the changes
     Then the amended value for Business Unit Type and Business Unit should be saved to the case
 
+  @TORegression
+  Scenario: As a Draft user, I want to be able to close the case early, so transferred or duplicate cases can be removed from the teams workstack
+    When I select to close the Treat Official case
+    And I select a reason to close the case
+    And I submit supporting details for the closure
+    Then the case should be closed
+    And the closure reason and details should be visible in the Case Details accordion
+    And the closure reason and details should be visible in the Summary tab
+    And a Case closure note should be visible in the timeline showing the submitted supporting details for closing the case
+
 

--- a/src/test/resources/features/to/QA.feature
+++ b/src/test/resources/features/to/QA.feature
@@ -54,3 +54,13 @@ Feature: QA
     And I select the "replacement draft" document as the primary draft
     And I save the change of the primary draft
     And the replacement document should be tagged as the primary draft
+
+  @TORegression
+  Scenario: As a QA user, I want to be able to close the case early, so transferred or duplicate cases can be removed from the teams workstack
+    When I select to close the Treat Official case
+    And I select a reason to close the case
+    And I submit supporting details for the closure
+    Then the case should be closed
+    And the closure reason and details should be visible in the Case Details accordion
+    And the closure reason and details should be visible in the Summary tab
+    And a Case closure note should be visible in the timeline showing the submitted supporting details for closing the case

--- a/src/test/resources/features/to/Triage.feature
+++ b/src/test/resources/features/to/Triage.feature
@@ -71,3 +71,14 @@ Feature: Triage
     And I save the changes
     Then the amended value for Channel Received should be saved to the case
 
+  @TORegression
+  Scenario: As a Triage user, I want to be able to close the case early, so transferred or duplicate cases can be removed from the teams workstack
+    When I select to close the Treat Official case
+    And I select a reason to close the case
+    And I submit supporting details for the closure
+    Then the case should be closed
+    And the closure reason and details should be visible in the Case Details accordion
+    And the closure reason and details should be visible in the Summary tab
+    And a Case closure note should be visible in the timeline showing the submitted supporting details for closing the case
+
+


### PR DESCRIPTION
Amended TO Data Input scenario to remove example for selecting a MP Recipient.

Amended the steps for recipient adding to no longer be parameterized for recipient type.