### PR TITLE
HOCS-4553 BF: Remove 'Complaint Category screen' from Stage 1 workflow

### DIFF
--- a/src/test/java/com/hocs/test/glue/complaints/RegistrationStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/RegistrationStepDefs.java
@@ -32,7 +32,7 @@ public class RegistrationStepDefs extends BasePage {
 
     @And("I select {string} as the Complaint Type")
     public void iSelectAsTheComplaintType(String complaintType) {
-        registration.selectComplaintType(complaintType);
+        registration.selectASpecificComplaintType(complaintType);
     }
 
     @And("I enter the complaint details on the Complaint Input page")

--- a/src/test/java/com/hocs/test/glue/decs/ValidationStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/ValidationStepDefs.java
@@ -1134,7 +1134,7 @@ public class ValidationStepDefs extends BasePage {
                                 correspondents.confirmPrimaryCorrespondent();
                                 waitABit(500);
                                 safeClickOn(continueButton);
-                                registration.selectComplaintType("Service");
+                                registration.selectASpecificComplaintType("Service");
                                 registration.selectASeverity();
                                 safeClickOn(continueButton);
                                 break;
@@ -1143,7 +1143,7 @@ public class ValidationStepDefs extends BasePage {
                                 correspondents.confirmPrimaryCorrespondent();
                                 waitABit(500);
                                 safeClickOn(continueButton);
-                                registration.selectComplaintType("Service");
+                                registration.selectASpecificComplaintType("Service");
                                 registration.selectAChannel();
                                 safeClickOn(continueButton);
                                 break;
@@ -1152,7 +1152,7 @@ public class ValidationStepDefs extends BasePage {
                                 correspondents.confirmPrimaryCorrespondent();
                                 waitABit(500);
                                 safeClickOn(continueButton);
-                                registration.selectComplaintType("Service");
+                                registration.selectASpecificComplaintType("Service");
                                 registration.selectAChannel();
                                 registration.selectASeverity();
                                 safeClickOn(continueButton);
@@ -1165,7 +1165,7 @@ public class ValidationStepDefs extends BasePage {
                                 correspondents.confirmPrimaryCorrespondent();
                                 waitABit(500);
                                 safeClickOn(continueButton);
-                                registration.selectComplaintType("Service");
+                                registration.selectASpecificComplaintType("Service");
                                 registration.selectAChannel();
                                 registration.selectASeverity();
                                 safeClickOn(continueButton);

--- a/src/test/java/com/hocs/test/pages/complaints/BFProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/complaints/BFProgressCase.java
@@ -110,7 +110,7 @@ public class BFProgressCase extends BasePage {
                 moveBFCaseFromDraftToQA();
                 break;
             case "QA":
-                moveCaseFromQAToSend();
+                moveBCaseFromQAToSend();
                 break;
             case "SEND":
                 moveBFCaseFromSendToCaseClosed();
@@ -127,27 +127,20 @@ public class BFProgressCase extends BasePage {
         correspondents.addANonMemberCorrespondentOfType("Complainant");
         clickTheButton("Continue");
         registration.enterComplainantDetails();
-        registration.selectComplaintType("Service");
+        registration.selectAComplaintType();
         registration.selectAChannel();
         registration.enterADescriptionOfTheComplaint();
-        //TODO remove the below commented line after testing manually
-//        registration.enterAPreviousUKVIComplaintReference();
+        registration.enterAPreviousComplaintReference();
         registration.enterAThirdPartyReference();
         clickTheButton("Continue");
-        registration.openTheServiceComplaintCategoryAccordion();
-        waitABit(1000);
-        registration.selectAVisibleClaimCategory();
-        registration.selectAnOwningCSU();
-        clickTheButton("Finish");
-        System.out.println("Case moved from Registration to Triage");
-
+        System.out.println("Case moved from Case Registration to Case Triage");
     }
 
     public void moveBFCaseFromTriageToDraft() {
         complaintsTriage.enterDetailsOnBFTriageCaptureReasonPage();
         clickTheButton("Continue");
         complaintsTriage.selectReadyForDrafting();
-        System.out.println("Case moved from Service Triage to Draft");
+        System.out.println("Case moved from Case Triage to Draft");
     }
 
     public void moveBFCaseFromTriageToEscalated() {
@@ -155,37 +148,26 @@ public class BFProgressCase extends BasePage {
         complaintsTriage.enterDetailsOnBFTriageCaptureReasonPage();
         clickTheButton("Continue");
         complaintsTriage.escalateCaseToWFM();
+        System.out.println("Case moved from Case Triage to Escalated to WFM");
     }
 
     public void moveBFCaseFromDraftToQA() {
         documents.addADocumentOfDocumentType("DRAFT");
         complaintsDraft.selectActionAtServiceDraft("Send Case to QA");
+        System.out.println("Case moved from Draft to QA");
     }
 
-    //TODO: Remove below method at the time of refactoring
-/*    public void moveBFCaseFromDraftToWFM() {
-        documents.addADocumentOfDocumentType("DRAFT");
-        complaintsTriage.escalateCaseToWFM();
-    }*/
-
-    //TODO: Remove below method at the time of refactoring
-/*    public void moveBFCaseFromDraftToSend() {
-        documents.addADocumentOfDocumentType("DRAFT");
-        clickTheButton("Response Ready");
-        System.out.println("Case moved from Draft to Send");
-    }*/
+    public void moveBCaseFromQAToSend() {
+        compQA.selectActionAtServiceQA("ACCEPT");
+        System.out.println("Case moved from QA to Send draft response");
+    }
 
     public void moveBFCaseFromSendToCaseClosed() {
         complaintsSend.selectACaseOutcome();
         complaintsSend.selectAResponseChannel();
-        //TODO raise a defect as the date is prepopulated
-//        complaintsSend.enterADateOfResponse();
+        complaintsSend.enterADateOfResponse();
         clickTheButton("Complete");
-        System.out.println("Case moved from Send to Closed");
-    }
-
-    public void moveCaseFromQAToSend() {
-        compQA.selectActionAtServiceQA("ACCEPT");
+        System.out.println("Case moved from Send draft response to Case Closed");
     }
 
     public void generateBFSearchCaseData(String infoValue, String infoType) {

--- a/src/test/java/com/hocs/test/pages/complaints/COMPProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/complaints/COMPProgressCase.java
@@ -9,7 +9,6 @@ import com.hocs.test.pages.decs.Dashboard;
 import com.hocs.test.pages.decs.Documents;
 import com.hocs.test.pages.decs.RecordCaseData;
 import com.hocs.test.pages.decs.Search;
-import java.text.ParseException;
 import net.serenitybdd.core.pages.WebElementFacade;
 import org.junit.Assert;
 
@@ -191,7 +190,7 @@ public class COMPProgressCase extends BasePage {
         correspondents.addANonMemberCorrespondentOfType("Complainant");
         correspondents.confirmPrimaryCorrespondent();
         registration.enterComplainantDetails();
-        registration.selectComplaintType(complaintType);
+        registration.selectASpecificComplaintType(complaintType);
         registration.enterComplaintDetails();
         if (complaintType.equalsIgnoreCase("SERVICE")) {
             clickTheButton("Continue");
@@ -289,7 +288,7 @@ public class COMPProgressCase extends BasePage {
                 registration.enterAHomeOfficeReference("Test entry for Home Office Reference");
                 registration.enterAPortReference();
                 safeClickOn(continueButton);
-                registration.selectComplaintType("Service");
+                registration.selectASpecificComplaintType("Service");
                 registration.selectAChannel();
                 registration.selectASeverity();
                 safeClickOn(continueButton);

--- a/src/test/java/com/hocs/test/pages/complaints/IEDETProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/complaints/IEDETProgressCase.java
@@ -87,7 +87,7 @@ public class IEDETProgressCase extends BasePage {
         correspondents.addANonMemberCorrespondentOfType("Complainant");
         correspondents.confirmPrimaryCorrespondent();
         registration.enterComplainantDetails();
-        registration.selectComplaintType("Service");
+        registration.selectASpecificComplaintType("Service");
         registration.selectAChannel();
         registration.selectComplaintOrigin();
         registration.enterADescriptionOfTheComplaint();

--- a/src/test/java/com/hocs/test/pages/complaints/Registration.java
+++ b/src/test/java/com/hocs/test/pages/complaints/Registration.java
@@ -204,7 +204,7 @@ public class Registration extends BasePage {
         clickTheButton("Continue");
     }
 
-    public void selectComplaintType(String complaintType) {
+    public void selectASpecificComplaintType(String complaintType) {
         switch (complaintType.toUpperCase()) {
             case "SERVICE":
                 recordCaseData.selectSpecificRadioButtonFromGroupWithHeading("Service", "Complaint Type");
@@ -223,6 +223,11 @@ public class Registration extends BasePage {
         }
         clickTheButton("Continue");
         System.out.println("Complaint type: " + complaintType);
+    }
+
+    public void selectAComplaintType() {
+        String complaintType = recordCaseData.selectRandomRadioButtonFromGroupWithHeading("Complaint Type");
+        setSessionVariable("complaintType").to(complaintType);
     }
 
     public void selectAChannel() {
@@ -254,6 +259,10 @@ public class Registration extends BasePage {
 
     public void enterAPreviousUKVIComplaintReference() {
         recordCaseData.enterTextIntoTextFieldWithHeading("Previous UKVI Complaint Ref");
+    }
+
+    public void enterAPreviousComplaintReference() {
+        recordCaseData.enterTextIntoTextFieldWithHeading("Previous Complaint Reference");
     }
 
     public void enterAThirdPartyReference() { recordCaseData.enterTextIntoTextFieldWithHeading("Third Party Reference");

--- a/src/test/resources/features/complaints/Actions.feature
+++ b/src/test/resources/features/complaints/Actions.feature
@@ -4,7 +4,7 @@ Feature: Actions
   Background:
     Given I am logged into "CS" as user "BF_USER"
 
-#    HOCS-4395, HOCS-4396, HOCS-5437
+  # HOCS-4395, HOCS-4396, HOCS-5437
   @ComplaintsRegression
   Scenario: User is able to add and update a Registered Interest in a Border Force Complaints case
     And I create a single "BF" case

--- a/src/test/resources/features/complaints/CCH.feature
+++ b/src/test/resources/features/complaints/CCH.feature
@@ -8,7 +8,7 @@ Feature: CCH
 
 #    HOCS-2944
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can transfer the case to CCT
+  Scenario: User can transfer a UKVI complaints case to CCT
     And I select the "Transfer to CCT" action at CCH
     Then the case should be moved to the "Service Triage" stage
     And the summary should display the owning team as "CCT Stage 1 Triage Team"
@@ -16,7 +16,7 @@ Feature: CCH
     And the read-only Case Details accordion should contain all case information entered during the "CCH" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can transfer the case to Ex-Gratia
+  Scenario: User can transfer a UKVI complaints case to Ex-Gratia
     And I select the "Transfer to Ex-Gratia" action at CCH
     Then the case should be moved to the "Ex-Gratia Triage" stage
     And the summary should display the owning team as "Ex-Gratia"
@@ -24,7 +24,7 @@ Feature: CCH
     And the read-only Case Details accordion should contain all case information entered during the "CCH" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can transfer the case to Minor Misconduct
+  Scenario: User can transfer a UKVI complaints case to Minor Misconduct
     And I select the "Transfer to Minor Misconduct" action at CCH
     Then the case should be moved to the "Minor Misconduct Triage" stage
     And the summary should display the owning team as "Minor Misconduct"
@@ -33,7 +33,7 @@ Feature: CCH
 
 #    HOCS-3025
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can hard close a case at CCH stage
+  Scenario: User can hard close a UKVI complaints case at CCH stage
     And I select the "Complete the Case" action at CCH
     And I enter a completion note at CCH
     And I confirm I want to close the case at CCH
@@ -42,7 +42,7 @@ Feature: CCH
     And the read-only Case Details accordion should contain all case information entered during the "CCH" stage
 
   @Validation
-  Scenario Outline: User tests the validation at CCH
+  Scenario Outline: User tests the validation for a UKVI complaints case at CCH stage
     And I trigger the "<errorType>" error message at "CCH"
     Then the "<errorType>" error message is displayed at "CCH"
     Examples:

--- a/src/test/resources/features/complaints/ComplaintsDraft.feature
+++ b/src/test/resources/features/complaints/ComplaintsDraft.feature
@@ -1,9 +1,12 @@
 @ComplaintsDraft @Complaints
 Feature: Complaints Draft
 
-#   HOCS-3695
+
+#     UKVI COMPLAINTS
+
+  # HOCS-3695
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User sends the case to Service Send stage
+  Scenario: User can send a UKVI complaint case to Service Send stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Draft" stage
     And I load and claim the current case
@@ -14,7 +17,7 @@ Feature: Complaints Draft
     And the read-only Case Details accordion should contain all case information entered during the "Service Draft" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User sends the case to Ex-Gratia Send stage
+  Scenario: User can send a UKVI complaint case to Ex-Gratia Send stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia Response Draft" stage
     And I load and claim the current case
@@ -25,7 +28,7 @@ Feature: Complaints Draft
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia Response Draft" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User sends the case to Minor Misconduct Send stage
+  Scenario: User can send a UKVI complaint case to Minor Misconduct Send stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct Response Draft" stage
     And I load and claim the current case
@@ -35,38 +38,9 @@ Feature: Complaints Draft
     And the summary should display the owning team as "Minor Misconduct"
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct Response Draft" stage
 
+  # HOCS-3695
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User completes the Draft stage for an IEDET case
-    Given I am logged into "CS" as user "IEDET_USER"
-    When I create a "IEDET" case and move it to the "Draft" stage
-    And I load and claim the current case
-    And I click the "Proceed to recording outcome" button
-    Then the case should be moved to the "Send" stage
-    And the summary should display the owning team as "IE Detention"
-
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User completes the Draft stage for an SMC case
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Draft" stage
-    And I load and claim the current case
-    And I add a "DRAFT" type document to the case
-    And I click the "Response Ready" button
-    Then the case should be moved to the "Send" stage
-    And the summary should display the owning team as "Serious Misconduct"
-
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User completes the Draft stage for a BF case
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Draft" stage
-    And I add a "DRAFT" type document to the case
-    And I select the "Response is Ready to Send" action at the Draft stage
-    Then the case should be moved to the "Send draft response" stage
-    And the summary should display the owning team as "Border Force"
-    And the read-only Case Details accordion should contain all case information entered during the "Draft" stage
-
-#    HOCS-3695
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User sends the case to Service QA stage
+  Scenario: User can send a UKVI complaint case to Service QA stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Draft" stage
     And I load and claim the current case
@@ -77,7 +51,7 @@ Feature: Complaints Draft
     And the read-only Case Details accordion should contain all case information entered during the "Service Draft" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User sends the case to Ex-Gratia QA stage
+  Scenario: User can send a UKVI complaint case to Ex-Gratia QA stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia Response Draft" stage
     And I load and claim the current case
@@ -88,7 +62,7 @@ Feature: Complaints Draft
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia Response Draft" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User sends the case to Minor Misconduct QA stage
+  Scenario: User can send a UKVI complaint case to Minor Misconduct QA stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct Response Draft" stage
     And I load and claim the current case
@@ -99,17 +73,7 @@ Feature: Complaints Draft
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct Response Draft" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User sends a BF case to the QA stage from Draft
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Draft" stage
-    And I add a "DRAFT" type document to the case
-    And I select the "Send case to QA" action at the Draft stage
-    Then the case should be moved to the "QA" stage
-    And the summary should display the owning team as "Border Force"
-    And the read-only Case Details accordion should contain all case information entered during the "Draft" stage
-
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User is able to escalate a COMP case to WFM at Service Draft stage
+  Scenario: User is able to escalate a UKVI complaint case to WFM at Service Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Draft" stage
     And I load and claim the current case
@@ -120,19 +84,7 @@ Feature: Complaints Draft
     And the read-only Case Details accordion should contain all case information entered during the "Service Draft" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User is able to escalate a BF case to WFM at Draft stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I create a "BF" case and move it to the "Draft" stage
-    And I load and claim the current case
-    And I add a "DRAFT" type document to the case
-    And I escalate the case to WFM at Draft stage
-    Then the case should be moved to the "Escalated to WFM" stage
-    And the summary should display the owning team as "Border Force"
-    And an Escalation note should be visible in the timeline showing the submitted reason for the cases escalation
-    And the read-only Case Details accordion should contain all case information entered during the "Draft" stage
-
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User is able to escalate a case to WFM at Ex-Gratia Response Draft stage
+  Scenario: User is able to escalate a UKVI complaint case to WFM at Ex-Gratia Response Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia Response Draft" stage
     And I load and claim the current case
@@ -143,7 +95,7 @@ Feature: Complaints Draft
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia Response Draft" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User is able to escalate a case to WFM at Minor Misconduct Response Draft stage
+  Scenario: User is able to escalate a UKVI complaint case to WFM at Minor Misconduct Response Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct Response Draft" stage
     And I load and claim the current case
@@ -153,9 +105,9 @@ Feature: Complaints Draft
     And an Escalation note should be visible in the timeline showing the submitted reason for the cases escalation
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct Response Draft" stage
 
-#    HOCS-3076
+  # HOCS-3076
   @Validation
-  Scenario: User must upload a document at Service Draft stage
+  Scenario: User must upload a document at Service Draft stage for a UKVI complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Draft" stage
     And I load and claim the current case
@@ -163,7 +115,7 @@ Feature: Complaints Draft
     Then an error message is displayed as I have not uploaded a document
 
   @Validation
-  Scenario Outline: User tests the validation at the Service Draft stage
+  Scenario Outline: User tests the validation for a UKVI complaint case at the Service Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Draft" stage
     And I load and claim the current case
@@ -174,3 +126,63 @@ Feature: Complaints Draft
       | PRIMARY DRAFT DOCUMENT REQUIRED  |
       | ACTION REQUIRED                  |
       | ESCALATION REASON                |
+
+
+#     IEDET COMPLAINTS
+
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User completes the Draft stage for an IEDET complaint case
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to the "Draft" stage
+    And I load and claim the current case
+    And I click the "Proceed to recording outcome" button
+    Then the case should be moved to the "Send" stage
+    And the summary should display the owning team as "IE Detention"
+
+
+#     SMC COMPLAINTS
+
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User completes the Draft stage for an SMC complaint case
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Draft" stage
+    And I load and claim the current case
+    And I add a "DRAFT" type document to the case
+    And I click the "Response Ready" button
+    Then the case should be moved to the "Send" stage
+    And the summary should display the owning team as "Serious Misconduct"
+
+
+#     BF COMPLAINTS
+
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User completes the Draft stage for a BF complaint case
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Draft" stage
+    And I add a "DRAFT" type document to the case
+    And I select the "Response is Ready to Send" action at the Draft stage
+    Then the case should be moved to the "Send draft response" stage
+    And the summary should display the owning team as "Border Force"
+    And the read-only Case Details accordion should contain all case information entered during the "Draft" stage
+
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User can send a BF complaint case to the QA stage from Draft
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Draft" stage
+    And I add a "DRAFT" type document to the case
+    And I select the "Send case to QA" action at the Draft stage
+    Then the case should be moved to the "QA" stage
+    And the summary should display the owning team as "Border Force"
+    And the read-only Case Details accordion should contain all case information entered during the "Draft" stage
+
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User is able to escalate a BF complaint case to WFM at Draft stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I create a "BF" case and move it to the "Draft" stage
+    And I load and claim the current case
+    And I add a "DRAFT" type document to the case
+    And I escalate the case to WFM at Draft stage
+    Then the case should be moved to the "Escalated to WFM" stage
+    And the summary should display the owning team as "Border Force"
+    And an Escalation note should be visible in the timeline showing the submitted reason for the cases escalation
+    And the read-only Case Details accordion should contain all case information entered during the "Draft" stage

--- a/src/test/resources/features/complaints/ComplaintsEndToEnd.feature
+++ b/src/test/resources/features/complaints/ComplaintsEndToEnd.feature
@@ -1,22 +1,12 @@
 @ComplaintsEndToEnd @ComplaintsWorkflow @Complaints
 Feature: Complaints End To End
 
-  Scenario Outline: User creates a Complaint case and it starts at the Registration stage
-    Given I am logged into "CS" as user "<caseType>_USER"
-    When I create a "<caseType>" case and move it to the "Registration" stage
-    Then the case should be moved to the "<stageName>" stage
-    Examples:
-      | caseType | stageName        |
-      | COMP     | Registration     |
-      | IEDET    | Registration     |
-      | SMC      | Registration     |
-      | BF       | Case Registration|
+#     UKVI STAGE 1 COMPLAINTS
 
-  Scenario: User creates a UKVI stage 2 complaint case and it starts at the Registration stage
+  Scenario: User creates a UKVI stage 1 complaint case and it starts at the Registration stage
     Given I am logged into "CS" as user "COMP_USER"
-    When I create a "COMP2" case and move it to the "Stage 2 Registration" stage
-    Then the case should be moved to the "Stage 2 Registration" stage
-
+    When I create a "COMP" case and move it to the "Registration" stage
+    Then the case should be moved to the "Registration" stage
 
   Scenario Outline: User moves a UKVI stage 1 complaint case to the Triage stage
     Given I am logged into "CS" as user "COMP_USER"
@@ -27,25 +17,6 @@ Feature: Complaints End To End
       | Service          |
       | Ex-Gratia        |
       | Minor Misconduct |
-
-  Scenario Outline: User moves a BF complaint case to the Triage stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I create a "BF" case for a "<complaintType>" complaint and move it to "Triage"
-    Then the case should be moved to the "Case Triage" stage
-    Examples:
-      | complaintType    |
-      | Service          |
-      | Minor Misconduct |
-
-  Scenario: User moves an IEDET complaint case to the Triage stage
-    Given I am logged into "CS" as user "IEDET_USER"
-    When I create a "IEDET" case and move it to the "Triage" stage
-    Then the case should be moved to the "Triage" stage
-
-  Scenario: User moves an SMC complaint case to the Triage stage
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Triage" stage
-    Then the case should be moved to the "Triage" stage
 
   Scenario Outline: User moves a UKVI stage 1 complaint case to CCH stage
     Given I am logged into "CS" as user "COMP_USER"
@@ -68,16 +39,6 @@ Feature: Complaints End To End
       | Ex-Gratia        | Escalate    |
       | Minor Misconduct | Escalate    |
 
-
-  Scenario Outline: User moves a BF complaint case to the Escalated stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I create a "BF" case for a "<complaintType>" complaint and move it to "<targetStage>" stage
-    Then the case should be moved to "<targetStage>" stage
-    Examples:
-      | complaintType    | targetStage      |
-      | Service          | Escalated to WFM |
-      | Minor Misconduct | Escalated to WFM |
-
   Scenario Outline: User moves a UKVI stage 1 complaint case to the Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case for a "<complaintType>" complaint and move it to "<complaintType> Draft"
@@ -88,21 +49,6 @@ Feature: Complaints End To End
       | Ex-Gratia        | Response Draft |
       | Minor Misconduct | Response Draft |
 
-  Scenario Outline: User moves a BF complaint case to the Draft stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I create a "BF" case for a "<complaintType>" complaint and move it to "Draft"
-    Then the case should be moved to "<targetStage>" stage
-    Examples:
-      | complaintType    | targetStage    |
-      | Service          | Draft          |
-      | Minor Misconduct | Draft          |
-
-
-  Scenario: User moves an IEDET complaint case to the Draft stage
-    Given I am logged into "CS" as user "IEDET_USER"
-    When I create a "IEDET" case and move it to the "Draft" stage
-    Then the case should be moved to the "Draft" stage
-
   Scenario Outline: User moves a UKVI stage 1 complaint case to the QA stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case for a "<complaintType>" complaint and move it to "<complaintType> QA"
@@ -111,15 +57,6 @@ Feature: Complaints End To End
       | complaintType    |
       | Service          |
       | Ex-Gratia        |
-      | Minor Misconduct |
-
-  Scenario Outline: User moves a BF complaint case to the QA stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I create a "BF" case for a "<complaintType>" complaint and move it to "QA"
-    Then the case should be moved to the "QA" stage
-    Examples:
-      | complaintType    |
-      | Service          |
       | Minor Misconduct |
 
   Scenario Outline: User moves a UKVI stage 1 complaint case to the Send stage
@@ -132,25 +69,6 @@ Feature: Complaints End To End
       | Ex-Gratia        |
       | Minor Misconduct |
 
-  Scenario Outline: User moves a BF complaint to the Send stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I create a "BF" case for a "<complaintType>" complaint and move it to "Send"
-    Then the case should be moved to the "Send draft response" stage
-    Examples:
-      | complaintType    |
-      | Service          |
-      | Minor Misconduct |
-
-  Scenario: User moves an IEDET complaint case to the Send stage
-    Given I am logged into "CS" as user "IEDET_USER"
-    When I create a "IEDET" case and move it to the "Send" stage
-    Then the case should be moved to the "Send" stage
-
-  Scenario: User moves an SMC complaint case to the Send stage
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Send" stage
-    Then the case should be moved to the "Send" stage
-
   @ComplaintsRegression @Smoketests
   Scenario Outline: User is able to close a UKVI stage 1 complaint case
     Given I am logged into "CS" as user "COMP_USER"
@@ -162,29 +80,10 @@ Feature: Complaints End To End
       | Ex-Gratia        |
       | Minor Misconduct |
 
-  @ComplaintsRegression @Smoketests
-  Scenario Outline: User is able to close a BF stage 1 complaint case
-    Given I am logged into "CS" as user "BF_USER"
-    When I create a "BF" case for a "<complaintType>" complaint and move it to "Closed"
-    Then the case should be closed
-    Examples:
-      | complaintType    |
-      | Service          |
-      | Minor Misconduct |
 
-  @ComplaintsRegression
-  Scenario: User is able to close an IEDET complaint case
-    Given I am logged into "CS" as user "IEDET_USER"
-    When I create a "IEDET" case and move it to "Case Closed"
-    Then the case should be closed
+#     UKVI STAGE 2 COMPLAINTS
 
-  @ComplaintsRegression
-  Scenario: User is able to close an SMC complaint case
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to "Case Closed"
-    Then the case should be closed
-
-  Scenario: User moves a COMP case to the Stage 2 Registration stage
+  Scenario: User creates a UKVI stage 2 complaint case and it starts at the Registration stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP2" case and move it to the "Stage 2 Registration" stage
     Then the case should be moved to the "Stage 2 Registration" stage
@@ -199,7 +98,7 @@ Feature: Complaints End To End
       | Ex-Gratia     |
       | MM            |
 
-  Scenario Outline: User moves a COMP case to the Stage 2 Draft stage
+  Scenario Outline: User moves a UKVI stage 2 complaint case to the Stage 2 Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP2" case and move it to the "Stage 2 <complaintType> Draft" stage
     Then the case should be moved to the "Stage 2 <complaintType> Draft" stage
@@ -209,7 +108,7 @@ Feature: Complaints End To End
       | Ex-Gratia Response |
       | MM Response        |
 
-  Scenario Outline: User moves a COMP case to the Stage 2 QA stage
+  Scenario Outline: User moves a UKVI stage 2 complaint case to the Stage 2 QA stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP2" case and move it to the "Stage 2 <complaintType> QA" stage
     Then the case should be moved to the "Stage 2 <complaintType> QA" stage
@@ -219,7 +118,7 @@ Feature: Complaints End To End
       | Ex-Gratia     |
       | MM            |
 
-  Scenario Outline: User moves a COMP case to the Stage 2 Send stage
+  Scenario Outline: User moves a UKVI stage 2 complaint case to the Stage 2 Send stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP2" case and move it to the "Stage 2 <complaintType> Send" stage
     Then the case should be moved to the "Stage 2 <complaintType> Send" stage
@@ -229,17 +128,129 @@ Feature: Complaints End To End
       | Ex-Gratia     |
       | MM            |
 
-  Scenario Outline: User moves a COMP case to the Stage 2 Complaint Closed stage
+  @ComplaintsRegression
+  Scenario Outline: User is able to close a UKVI stage 2 complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP2" case for a "<complaintType>" complaint and move it to "Stage 2 Complaint Closed" stage
-    Then the case should be moved to the "Stage 2 Complaint Closed" stage
+    Then the case should be closed
     Examples:
-      | complaintType |
-      | Ex-Gratia     |
-      | MM            |
+      | complaintType    |
+      | Service          |
+      | Ex-Gratia        |
+      | Minor Misconduct |
+
+
+#     IEDET COMPLAINTS
+
+  Scenario: User creates a IEDET complaint case and it starts at the Registration stage
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to the "Registration" stage
+    Then the case should be moved to the "Registration" stage
+
+  Scenario: User moves an IEDET complaint case to the Triage stage
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to the "Triage" stage
+    Then the case should be moved to the "Triage" stage
+
+  Scenario: User moves an IEDET complaint case to the Draft stage
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to the "Draft" stage
+    Then the case should be moved to the "Draft" stage
+
+  Scenario: User moves an IEDET complaint case to the Send stage
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to the "Send" stage
+    Then the case should be moved to the "Send" stage
 
   @ComplaintsRegression
-  Scenario: User is able to close a UKVI stage 2 complaint case
-    Given I am logged into "CS" as user "COMP_USER"
-    When I create a "COMP2" case and move it to the "Stage 2 Complaint Closed" stage
+  Scenario: User is able to close an IEDET complaint case
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to "Case Closed"
     Then the case should be closed
+
+
+#     SMC COMPLAINTS
+
+  Scenario: User creates a SMC complaint case and it starts at the Registration stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Registration" stage
+    Then the case should be moved to the "Registration" stage
+
+  Scenario: User moves an SMC complaint case to the Triage stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Triage" stage
+    Then the case should be moved to the "Triage" stage
+
+  Scenario: User moves an SMC complaint case to the Send stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Send" stage
+    Then the case should be moved to the "Send" stage
+
+  @ComplaintsRegression
+  Scenario: User is able to close an SMC complaint case
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to "Case Closed"
+    Then the case should be closed
+
+
+#     BF COMPLAINTS
+
+  Scenario: User creates a BF complaint case and it starts at the Registration stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I create a "BF" case and move it to the "Registration" stage
+    Then the case should be moved to the "Case Registration" stage
+
+  Scenario Outline: User moves a BF complaint case to the Triage stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I create a "BF" case for a "<complaintType>" complaint and move it to "Triage"
+    Then the case should be moved to the "Case Triage" stage
+    Examples:
+      | complaintType    |
+      | Service          |
+      | Minor Misconduct |
+
+  Scenario Outline: User moves a BF complaint case to the Escalated stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I create a "BF" case for a "<complaintType>" complaint and move it to "<targetStage>" stage
+    Then the case should be moved to "<targetStage>" stage
+    Examples:
+      | complaintType    | targetStage      |
+      | Service          | Escalated to WFM |
+      | Minor Misconduct | Escalated to WFM |
+
+  Scenario Outline: User moves a BF complaint case to the Draft stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I create a "BF" case for a "<complaintType>" complaint and move it to "Draft"
+    Then the case should be moved to "<targetStage>" stage
+    Examples:
+      | complaintType    | targetStage |
+      | Service          | Draft       |
+      | Minor Misconduct | Draft       |
+
+  Scenario Outline: User moves a BF complaint case to the QA stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I create a "BF" case for a "<complaintType>" complaint and move it to "QA"
+    Then the case should be moved to the "QA" stage
+    Examples:
+      | complaintType    |
+      | Service          |
+      | Minor Misconduct |
+
+  Scenario Outline: User moves a BF complaint to the Send stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I create a "BF" case for a "<complaintType>" complaint and move it to "Send"
+    Then the case should be moved to the "Send draft response" stage
+    Examples:
+      | complaintType    |
+      | Service          |
+      | Minor Misconduct |
+
+  @ComplaintsRegression @Smoketests
+  Scenario Outline: User is able to close a BF stage 1 complaint case
+    Given I am logged into "CS" as user "BF_USER"
+    When I create a "BF" case for a "<complaintType>" complaint and move it to "Closed"
+    Then the case should be closed
+    Examples:
+      | complaintType    |
+      | Service          |
+      | Minor Misconduct |

--- a/src/test/resources/features/complaints/ComplaintsEndToEnd.feature
+++ b/src/test/resources/features/complaints/ComplaintsEndToEnd.feature
@@ -1,7 +1,7 @@
 @ComplaintsEndToEnd @ComplaintsWorkflow @Complaints
 Feature: Complaints End To End
 
-  Scenario Outline: User moves a complaints case to the Registration stage
+  Scenario Outline: User creates a Complaint case and it starts at the Registration stage
     Given I am logged into "CS" as user "<caseType>_USER"
     When I create a "<caseType>" case and move it to the "Registration" stage
     Then the case should be moved to the "<stageName>" stage
@@ -12,7 +12,13 @@ Feature: Complaints End To End
       | SMC      | Registration     |
       | BF       | Case Registration|
 
-  Scenario Outline: User moves a COMP case to the Triage stage
+  Scenario: User creates a UKVI stage 2 complaint case and it starts at the Registration stage
+    Given I am logged into "CS" as user "COMP_USER"
+    When I create a "COMP2" case and move it to the "Stage 2 Registration" stage
+    Then the case should be moved to the "Stage 2 Registration" stage
+
+
+  Scenario Outline: User moves a UKVI stage 1 complaint case to the Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case for a "<complaintType>" complaint and move it to "<complaintType> Triage"
     Then the case should be moved to the "<complaintType> Triage" stage
@@ -22,7 +28,7 @@ Feature: Complaints End To End
       | Ex-Gratia        |
       | Minor Misconduct |
 
-  Scenario Outline: User moves a BF case to the Triage stage
+  Scenario Outline: User moves a BF complaint case to the Triage stage
     Given I am logged into "CS" as user "BF_USER"
     When I create a "BF" case for a "<complaintType>" complaint and move it to "Triage"
     Then the case should be moved to the "Case Triage" stage
@@ -31,17 +37,17 @@ Feature: Complaints End To End
       | Service          |
       | Minor Misconduct |
 
-  Scenario: User moves an IEDET case to the Triage stage
+  Scenario: User moves an IEDET complaint case to the Triage stage
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to the "Triage" stage
     Then the case should be moved to the "Triage" stage
 
-  Scenario: User moves an SMC case to the Triage stage
+  Scenario: User moves an SMC complaint case to the Triage stage
     Given I am logged into "CS" as user "SMC_USER"
     When I create a "SMC" case and move it to the "Triage" stage
     Then the case should be moved to the "Triage" stage
 
-  Scenario Outline: User moves a COMP case to CCH
+  Scenario Outline: User moves a UKVI stage 1 complaint case to CCH stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to "CCH"
     When I create a "COMP" case for a "<complaintType>" complaint and move it to "CCH" stage
@@ -52,7 +58,7 @@ Feature: Complaints End To End
       | Ex-Gratia        |
       | Minor Misconduct |
 
-  Scenario Outline: User moves a COMP case to the Escalated stage
+  Scenario Outline: User moves a UKVI stage 1 complaint case to the Escalated stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case for a "<complaintType>" complaint and move it to "<complaintType> <targetStage>" stage
     Then the case should be moved to "<complaintType> <targetStage>" stage
@@ -63,7 +69,7 @@ Feature: Complaints End To End
       | Minor Misconduct | Escalate    |
 
 
-  Scenario Outline: User moves a BF case to the Escalated stage
+  Scenario Outline: User moves a BF complaint case to the Escalated stage
     Given I am logged into "CS" as user "BF_USER"
     When I create a "BF" case for a "<complaintType>" complaint and move it to "<targetStage>" stage
     Then the case should be moved to "<targetStage>" stage
@@ -72,7 +78,7 @@ Feature: Complaints End To End
       | Service          | Escalated to WFM |
       | Minor Misconduct | Escalated to WFM |
 
-  Scenario Outline: User moves a COMP case to the Draft stage
+  Scenario Outline: User moves a UKVI stage 1 complaint case to the Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case for a "<complaintType>" complaint and move it to "<complaintType> Draft"
     Then the case should be moved to "<complaintType> <targetStage>" stage
@@ -82,7 +88,7 @@ Feature: Complaints End To End
       | Ex-Gratia        | Response Draft |
       | Minor Misconduct | Response Draft |
 
-  Scenario Outline: User moves a BF case to the Draft stage
+  Scenario Outline: User moves a BF complaint case to the Draft stage
     Given I am logged into "CS" as user "BF_USER"
     When I create a "BF" case for a "<complaintType>" complaint and move it to "Draft"
     Then the case should be moved to "<targetStage>" stage
@@ -92,12 +98,12 @@ Feature: Complaints End To End
       | Minor Misconduct | Draft          |
 
 
-  Scenario: User moves an IEDET case to the Draft stage
+  Scenario: User moves an IEDET complaint case to the Draft stage
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to the "Draft" stage
     Then the case should be moved to the "Draft" stage
 
-  Scenario Outline: User moves a COMP case to the QA stage
+  Scenario Outline: User moves a UKVI stage 1 complaint case to the QA stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case for a "<complaintType>" complaint and move it to "<complaintType> QA"
     Then the case should be moved to the "<complaintType> QA" stage
@@ -107,7 +113,7 @@ Feature: Complaints End To End
       | Ex-Gratia        |
       | Minor Misconduct |
 
-  Scenario Outline: User moves a BF case to the QA stage
+  Scenario Outline: User moves a BF complaint case to the QA stage
     Given I am logged into "CS" as user "BF_USER"
     When I create a "BF" case for a "<complaintType>" complaint and move it to "QA"
     Then the case should be moved to the "QA" stage
@@ -116,7 +122,7 @@ Feature: Complaints End To End
       | Service          |
       | Minor Misconduct |
 
-  Scenario Outline: User moves a COMP case to the Send stage
+  Scenario Outline: User moves a UKVI stage 1 complaint case to the Send stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case for a "<complaintType>" complaint and move it to "<complaintType> Send"
     Then the case should be moved to the "<complaintType> Send" stage
@@ -126,7 +132,7 @@ Feature: Complaints End To End
       | Ex-Gratia        |
       | Minor Misconduct |
 
-  Scenario Outline: User moves a BF case to the Send stage
+  Scenario Outline: User moves a BF complaint to the Send stage
     Given I am logged into "CS" as user "BF_USER"
     When I create a "BF" case for a "<complaintType>" complaint and move it to "Send"
     Then the case should be moved to the "Send draft response" stage
@@ -135,18 +141,18 @@ Feature: Complaints End To End
       | Service          |
       | Minor Misconduct |
 
-  Scenario: User moves an IEDET case to the Send stage
+  Scenario: User moves an IEDET complaint case to the Send stage
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to the "Send" stage
     Then the case should be moved to the "Send" stage
 
-  Scenario: User moves an SMC case to the Send stage
+  Scenario: User moves an SMC complaint case to the Send stage
     Given I am logged into "CS" as user "SMC_USER"
     When I create a "SMC" case and move it to the "Send" stage
     Then the case should be moved to the "Send" stage
 
   @ComplaintsRegression @Smoketests
-  Scenario Outline: User is able to close a COMP case
+  Scenario Outline: User is able to close a UKVI stage 1 complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case for a "<complaintType>" complaint and move it to "Complaint Closed"
     Then the case should be closed
@@ -157,7 +163,7 @@ Feature: Complaints End To End
       | Minor Misconduct |
 
   @ComplaintsRegression @Smoketests
-  Scenario Outline: User is able to close a BF case
+  Scenario Outline: User is able to close a BF stage 1 complaint case
     Given I am logged into "CS" as user "BF_USER"
     When I create a "BF" case for a "<complaintType>" complaint and move it to "Closed"
     Then the case should be closed
@@ -167,13 +173,13 @@ Feature: Complaints End To End
       | Minor Misconduct |
 
   @ComplaintsRegression
-  Scenario: User is able to close an IEDET case
+  Scenario: User is able to close an IEDET complaint case
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to "Case Closed"
     Then the case should be closed
 
   @ComplaintsRegression
-  Scenario: User is able to close an SMC case
+  Scenario: User is able to close an SMC complaint case
     Given I am logged into "CS" as user "SMC_USER"
     When I create a "SMC" case and move it to "Case Closed"
     Then the case should be closed
@@ -233,7 +239,7 @@ Feature: Complaints End To End
       | MM            |
 
   @ComplaintsRegression
-  Scenario: User is able to close a COMP2 case
+  Scenario: User is able to close a UKVI stage 2 complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP2" case and move it to the "Stage 2 Complaint Closed" stage
     Then the case should be closed

--- a/src/test/resources/features/complaints/ComplaintsEscalated.feature
+++ b/src/test/resources/features/complaints/ComplaintsEscalated.feature
@@ -1,9 +1,11 @@
 @ComplaintsEscalated @Complaints
 Feature: Complaints Escalated
 
-#    HOCS-3076, HOCS-3028
+#     UKVI COMPLAINTS
+
+  # HOCS-3076, HOCS-3028
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can return the case to Service Triage stage
+  Scenario: User can return a UKVI complaint case to Service Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Escalated" stage
     And I load and claim the current case
@@ -12,9 +14,9 @@ Feature: Complaints Escalated
     And the summary should display the owning team as "CCT Stage 1 Triage Team"
     And the read-only Case Details accordion should contain all case information entered during the "Service Escalated" stage
 
-#    HOCS-3076, HOCS-3028
+  # HOCS-3076, HOCS-3028
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can send the case to Service Draft stage
+  Scenario: User can send a UKVI complaint case to Service Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Escalated" stage
     And I load and claim the current case
@@ -23,9 +25,9 @@ Feature: Complaints Escalated
     And the summary should display the owning team as "CCT Stage 1 Response Team"
     And the read-only Case Details accordion should contain all case information entered during the "Service Escalated" stage
 
-#    Expected failure. Defect HOCS-4308 raised.
+  # Expected failure. Defect HOCS-4308 raised.
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can return the case to Ex-Gratia Triage stage
+  Scenario: User can return a UKVI complaint case to Ex-Gratia Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia Escalate" stage
     And I load and claim the current case
@@ -34,9 +36,9 @@ Feature: Complaints Escalated
     And the summary should display the owning team as "Ex-Gratia"
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia Escalate" stage
 
-#    Expected failure. Defect HOCS-4308 raised.
+  # Expected failure. Defect HOCS-4308 raised.
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can send the case to Ex-Gratia Response Draft stage
+  Scenario: User can send a UKVI complaint case to Ex-Gratia Response Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia Escalate" stage
     And I load and claim the current case
@@ -45,9 +47,9 @@ Feature: Complaints Escalated
     And the summary should display the owning team as "Ex-Gratia"
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia Escalate" stage
 
-#    Expected failure. Defect HOCS-4308 raised.
+  # Expected failure. Defect HOCS-4308 raised.
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can return the case to Minor Misconduct Triage stage
+  Scenario: User can return a UKVI complaint case to Minor Misconduct Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct Escalate" stage
     And I load and claim the current case
@@ -56,9 +58,9 @@ Feature: Complaints Escalated
     And the summary should display the owning team as "Minor Misconduct"
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct Escalate" stage
 
-#    Expected failure. Defect HOCS-4308 raised.
+  # Expected failure. Defect HOCS-4308 raised.
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can send the case to Minor Misconduct Response Draft stage
+  Scenario: User can send a UKVI complaint case to Minor Misconduct Response Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct Escalate" stage
     And I load and claim the current case
@@ -67,45 +69,12 @@ Feature: Complaints Escalated
     And the summary should display the owning team as "Minor Misconduct"
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct Escalate" stage
 
-  #HOCS-4055
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can send a BF case to Draft stage from Escalated
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Escalated to WFM" stage
-    And I select to send the case to drafting
-    Then the case should be moved to the "Draft" stage
-    And the summary should display the owning team as "Border Force"
-
-  #HOCS-4055
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can send a BF case to Triage stage from Escalated
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Escalated to WFM" stage
-    And I select to return the case to Triage
-    Then the case should be moved to the "Case Triage" stage
-    And the summary should display the owning team as "Border Force"
-
-#    HOCS-2870, HOCS-3096
+  # HOCS-2870, HOCS-3096
   @ComplaintsRegression
-  Scenario Outline: User can add and complete or cancel contributions as part of Service Escalated stage
+  Scenario Outline: User can add and complete or cancel contributions to a UKVI complaint case as part of Service Escalated stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Escalated" stage
     And I load and claim the current case
-    And I add a "<contributionType>" contribution request
-    And I "<action>" the contribution request
-    Then the "<contributionType>" contribution request should be marked as "<action>"
-    Examples:
-      | contributionType | action   |
-      | Complainant      | Complete |
-      | Complainant      | Cancel   |
-      | Business         | Complete |
-      | Business         | Cancel   |
-
-  #HOCS-4055
-  @ComplaintsRegression
-  Scenario Outline: User can add and complete or cancel contributions for BF cases as part of Escalated stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Escalated to WFM" stage
     And I add a "<contributionType>" contribution request
     And I "<action>" the contribution request
     Then the "<contributionType>" contribution request should be marked as "<action>"
@@ -117,7 +86,7 @@ Feature: Complaints Escalated
       | Business         | Cancel   |
 
   @Validation
-  Scenario Outline: User tests the validation at the Service Escalated stage
+  Scenario Outline: User tests the validation for a UKVI complaint case at the Service Escalated stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Escalated" stage
     And I load and claim the current case
@@ -126,3 +95,39 @@ Feature: Complaints Escalated
     Examples:
       | errorType       |
       | Action Required |
+
+
+#     BF COMPLAINTS
+
+  # HOCS-4055
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User can send a BF complaint case to Draft stage from Escalated
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Escalated to WFM" stage
+    And I select to send the case to drafting
+    Then the case should be moved to the "Draft" stage
+    And the summary should display the owning team as "Border Force"
+
+  # HOCS-4055
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User can send a BF complaint case to Triage stage from Escalated
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Escalated to WFM" stage
+    And I select to return the case to Triage
+    Then the case should be moved to the "Case Triage" stage
+    And the summary should display the owning team as "Border Force"
+
+  # HOCS-4055
+  @ComplaintsRegression
+  Scenario Outline: User can add and complete or cancel contributions to a BF complaint cases as part of Escalated stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Escalated to WFM" stage
+    And I add a "<contributionType>" contribution request
+    And I "<action>" the contribution request
+    Then the "<contributionType>" contribution request should be marked as "<action>"
+    Examples:
+      | contributionType | action   |
+      | Complainant      | Complete |
+      | Complainant      | Cancel   |
+      | Business         | Complete |
+      | Business         | Cancel   |

--- a/src/test/resources/features/complaints/ComplaintsQA.feature
+++ b/src/test/resources/features/complaints/ComplaintsQA.feature
@@ -1,9 +1,11 @@
 @ComplaintsQA @Complaints
 Feature: Complaints QA
 
-#    HOCS-3695
+#     UKVI COMPLAINTS
+
+  # HOCS-3695
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can accept the response and send the case to Service Send stage
+  Scenario: User can accept the response and send a UKVI complaint case to Service Send stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service QA" stage
     And I load and claim the current case
@@ -12,9 +14,9 @@ Feature: Complaints QA
     And the summary should display the owning team as "CCT Stage 1 Response Team"
     And the read-only Case Details accordion should contain all case information entered during the "Service QA" stage
 
-#    HOCS-3039
+  # HOCS-3039
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can reject the response and send the case back to Service Draft stage
+  Scenario: User can reject the response and send a UKVI complaint case back to Service Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service QA" stage
     And I load and claim the current case
@@ -25,7 +27,7 @@ Feature: Complaints QA
     And the read-only Case Details accordion should contain all case information entered during the "Service QA" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can accept the response and send the case to Ex-Gratia Send stage
+  Scenario: User can accept the response and send a UKVI complaint case to Ex-Gratia Send stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia QA" stage
     And I load and claim the current case
@@ -35,7 +37,7 @@ Feature: Complaints QA
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia QA" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can reject the response and send the case back to Ex-Gratia Response Draft stage
+  Scenario: User can reject the response and send a UKVI complaint case back to Ex-Gratia Response Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia QA" stage
     And I load and claim the current case
@@ -46,7 +48,7 @@ Feature: Complaints QA
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia QA" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can accept the response and send the case to Minor Misconduct Send stage
+  Scenario: User can accept the response and send a UKVI complaint case to Minor Misconduct Send stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct QA" stage
     And I load and claim the current case
@@ -56,7 +58,7 @@ Feature: Complaints QA
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct QA" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can reject the response and send the case back to Minor Misconduct Response Draft stage
+  Scenario: User can reject the response and send a UKVI complaint case back to Minor Misconduct Response Draft stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct QA" stage
     And I load and claim the current case
@@ -66,29 +68,8 @@ Feature: Complaints QA
     And a Rejection note should be visible in the timeline showing the submitted reason for the return of the case
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct QA" stage
 
-  #HOCS-4064
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can accept the response at the QA stage and send the BF case to the Send Draft Response stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "QA" stage
-    And I "accept" the response to the complaint at the QA stage
-    Then the case should be moved to the "Send Draft Response" stage
-    And the summary should display the owning team as "Border Force"
-    And the read-only Case Details accordion should contain all case information entered during the "QA" stage
-
-  #HOCS-4064, HOCS-4065
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can reject the response at the QA stage and send the BF case to the Draft stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "QA" stage
-    And I "reject" the response to the complaint at the QA stage
-    Then the case should be moved to the "Draft" stage
-    And the summary should display the owning team as "Border Force"
-    And a Rejection note should be visible in the timeline showing the submitted reason for the return of the case
-    And the read-only Case Details accordion should contain all case information entered during the "QA" stage
-
   @Validation
-  Scenario Outline: User tests the validation at the Service QA stage
+  Scenario Outline: User tests the validation for a UKVI complaints case at the Service QA stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service QA" stage
     And I load and claim the current case
@@ -98,3 +79,27 @@ Feature: Complaints QA
       | errorType                 |
       | QA RESULT REQUIRED        |
       | REJECTION REASON REQUIRED |
+
+
+#     BF COMPLAINTS
+
+  # HOCS-4064
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User can accept the response at the QA stage and send a BF complaint case to the Send Draft Response stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "QA" stage
+    And I "accept" the response to the complaint at the QA stage
+    Then the case should be moved to the "Send Draft Response" stage
+    And the summary should display the owning team as "Border Force"
+    And the read-only Case Details accordion should contain all case information entered during the "QA" stage
+
+  # HOCS-4064, HOCS-4065
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User can reject the response at the QA stage and send a BF complaint case back to the Draft stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "QA" stage
+    And I "reject" the response to the complaint at the QA stage
+    Then the case should be moved to the "Draft" stage
+    And the summary should display the owning team as "Border Force"
+    And a Rejection note should be visible in the timeline showing the submitted reason for the return of the case
+    And the read-only Case Details accordion should contain all case information entered during the "QA" stage

--- a/src/test/resources/features/complaints/ComplaintsRegistration.feature
+++ b/src/test/resources/features/complaints/ComplaintsRegistration.feature
@@ -1,9 +1,11 @@
 @Registration @Complaints
 Feature: Registration
 
-#   HOCS-2999, HOCS-2858, HOCS-2859, HOCS-2860, HOCS-2862, HOCS-2881, HOCS-2899, HOCS-2648
+#     UKVI COMPLAINTS
+
+  # HOCS-2999, HOCS-2858, HOCS-2859, HOCS-2860, HOCS-2862, HOCS-2881, HOCS-2899, HOCS-2648
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can complete the Registration stage for a Service complaint
+  Scenario: User can complete the Registration stage for a UKVI Service complaint case
     Given I am logged into "CS" as user "COMP_USER"
     And I create a single "COMP" case
     And I allocate the case to myself via the successful case creation screen
@@ -20,18 +22,8 @@ Feature: Registration
     And the summary should display the owning team as "CCT Stage 1 Triage Team"
     And the read-only Case Details accordion should contain all case information entered during the "Registration" stage
 
-#   HOCS-2709, HOCS-2858
-  @ComplaintsRegression
-  Scenario: User must add a Complainant type correspondent
-    Given I am logged into "CS" as user "COMP_USER"
-    And I create a single "COMP" case
-    And I allocate the case to myself via the successful case creation screen
-    And I add a "Third Party Representative" correspondent
-    When I confirm the primary correspondent
-    Then the "Complaint Correspondents Invalid" page should be displayed
-
-  #HOCS-3441, HOCS-3442
-  Scenario: User can complete the Registration stage for a Ex-Gratia complaint
+  # HOCS-3441, HOCS-3442
+  Scenario: User can complete the Registration stage for a UKVI Ex-Gratia complaint case
     Given I am logged into "CS" as user "COMP_USER"
     And I create a single "COMP" case
     And I allocate the case to myself via the successful case creation screen
@@ -45,7 +37,7 @@ Feature: Registration
     And the summary should display the owning team as "Ex-Gratia"
     And the read-only Case Details accordion should contain all case information entered during the "Registration" stage
 
-  Scenario: User can complete the Registration stage for a Minor Misconduct complaint
+  Scenario: User can complete the Registration stage for a UKVI Minor Misconduct complaint case
     Given I am logged into "CS" as user "COMP_USER"
     And I create a single "COMP" case
     And I allocate the case to myself via the successful case creation screen
@@ -59,8 +51,44 @@ Feature: Registration
     And the summary should display the owning team as "Minor Misconduct"
     And the read-only Case Details accordion should contain all case information entered during the "Registration" stage
 
+  # HOCS-2709, HOCS-2858
+  @ComplaintsRegression
+  Scenario: User must add a Complainant type correspondent to a UKVI Complaint case
+    Given I am logged into "CS" as user "COMP_USER"
+    And I create a single "COMP" case
+    And I allocate the case to myself via the successful case creation screen
+    And I add a "Third Party Representative" correspondent
+    When I confirm the primary correspondent
+    Then the "Complaint Correspondents Invalid" page should be displayed
+
+  Scenario: User can navigate to the relevant stage 1 UKVI complaint case from the summary of the stage 2 UKVI complaint case
+    Given I am logged into "CS" as user "COMP_USER"
+    And I create a "COMP2" case and move it to the "Stage 2 Registration" stage
+    And I load the current case
+    And I select the previous COMP case reference from the COMP2 case summary tab
+    Then the previous COMP case is displayed
+
+  @Validation
+  Scenario Outline: User tests the validation for a UKVI complaint case at the Registration stage
+    Given I am logged into "CS" as user "COMP_USER"
+    And I create a single "COMP" case
+    And I allocate the case to myself via the successful case creation screen
+    When I trigger the "<errorType>" error message at the "Registration" stage
+    Then the "<errorType>" error message is displayed at the "Registration" stage
+    Examples:
+      | errorType                       |
+      | PRIMARY CORRESPONDENT REQUIRED  |
+      | COMPLAINT TYPE REQUIRED         |
+      | CHANNEL REQUIRED                |
+      | SEVERITY REQUIRED               |
+      | OWNING CSU REQUIRED             |
+      | COMPLAINT TYPE OPTION REQUIRED  |
+
+
+#     IEDET COMPLAINTS
+
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can complete the Registration stage for an IEDET case
+  Scenario: User can complete the Registration stage for an IEDET complaint case
     Given I am logged into "CS" as user "IEDET_USER"
     And I create a single "IEDET" case
     And I allocate the case to myself via the successful case creation screen
@@ -77,8 +105,13 @@ Feature: Registration
     And the summary should display the owning team as "IE Detention"
     And the read-only Case Details accordion should contain all case information entered during the "Registration" stage
 
+
+#     SMC COMPLAINTS
+
+#     BF COMPLAINTS
+
   @ComplaintsRegression @ComplaintsWorkflow
-  Scenario: User is able to complete the Registration stage for a BF case
+  Scenario: User is able to complete the Registration stage for a BF complaint case
     Given I am logged into "CS" as user "BF_USER"
     When I create a single "BF" case
     And I allocate the case to myself via the successful case creation screen
@@ -88,32 +121,6 @@ Feature: Registration
     And I select "Service" as the Complaint Type
     And I enter the complaint details on the Complaint Input page
     And I click the "Continue" button
-    And I select a "Service" Complaint Category
-    And I select a Owning CSU
-    And I click the "Finish" button
     Then the case should be moved to the "Case Triage" stage
     And the summary should display the owning team as "Border Force"
     And the read-only Case Details accordion should contain all case information entered during the "Case Registration" stage
-
-  Scenario: User can navigate to a COMP case using the case reference displayed in COMP2 summary
-    Given I am logged into "CS" as user "COMP_USER"
-    And I create a "COMP2" case and move it to the "Stage 2 Registration" stage
-    And I load the current case
-    And I select the previous COMP case reference from the COMP2 case summary tab
-    Then the previous COMP case is displayed
-
-  @Validation
-  Scenario Outline: User tests the validation at the Registration stage
-    Given I am logged into "CS" as user "COMP_USER"
-    And I create a single "COMP" case
-    And I allocate the case to myself via the successful case creation screen
-    When I trigger the "<errorType>" error message at the "Registration" stage
-    Then the "<errorType>" error message is displayed at the "Registration" stage
-    Examples:
-    | errorType                       |
-    | PRIMARY CORRESPONDENT REQUIRED  |
-    | COMPLAINT TYPE REQUIRED         |
-    | CHANNEL REQUIRED                |
-    | SEVERITY REQUIRED               |
-    | OWNING CSU REQUIRED             |
-    | COMPLAINT TYPE OPTION REQUIRED  |

--- a/src/test/resources/features/complaints/ComplaintsSearch.feature
+++ b/src/test/resources/features/complaints/ComplaintsSearch.feature
@@ -1,9 +1,11 @@
 @ComplaintsSearch @Complaints
 Feature: Complaints Search
 
-#    HOCS-2838, HOCS-3036
+#     UKVI COMPLAINTS
+
+  # HOCS-2838, HOCS-3036
   @ComplaintsRegression
-  Scenario Outline: User tests COMP search criteria
+  Scenario Outline: User tests UKVI complaint case search criteria
     Given I am logged into "CS" as user "COMP_USER"
     When I navigate to the "Search" page
     And I enter "<infoValue>" into the "<infoType>" search field in the "COMP" search configuration
@@ -19,17 +21,36 @@ Feature: Complaints Search
       | Complainant Date Of Birth         | 01/01/2001                           |
       | Complainant Home Office Reference | Test entry for Home Office Reference |
 
-#    HOCS-2838
+  # HOCS-2838
   @ComplaintsRegression
-  Scenario: User can search for a COMP case by its case reference
+  Scenario: User can search for a UKVI complaint case by its case reference
     Given I am logged into "CS" as user "COMP_USER"
     When I create a single "COMP" case
     And I search for the case by its case reference
     Then the created case should be the only case visible in the search results
 
-  #HOCS-4079
+    # HOCS-2847 HOCS-3161
   @ComplaintsRegression
-  Scenario Outline: User tests BF search criteria
+  Scenario: UKVI complaints user sees the required information when viewing search results
+    Given I am logged into "CS" as user "COMP_USER"
+    When I navigate to the "search" page
+    And I click the search button on the search page
+    Then the "COMP Search" workstack should contain only the expected columns
+
+  Scenario: User is able to select a COMP2 case reference from the escalate case column of a COMP case
+    Given I am logged into "CS" as user "COMP_USER"
+    When I create a "COMP2" case and move it to the "Stage 2 Registration" stage
+    And I navigate to the "Search" page
+    And I search for the COMP case escalated to COMP2 by it's case reference
+    And I load the COMP2 case by selecting its case reference from the Escalate Case column
+    Then the case should be loaded
+
+
+#     BF COMPLAINTS
+
+  # HOCS-4079
+  @ComplaintsRegression
+  Scenario Outline: User tests BF complaint case search criteria
     Given I am logged into "CS" as user "BF_USER"
     When I navigate to the "Search" page
     And I enter "<infoValue>" into the "<infoType>" search field in the "BF" search configuration
@@ -43,26 +64,10 @@ Feature: Complaints Search
     | Complainant date of birth         | 01/01/2001                            |
     | Complainant Home Office Reference | Test entry for Home Office Reference  |
 
-  #HOCS-4079
+  # HOCS-4079
   @ComplaintsRegression
-  Scenario: User can search for a BF case by its case reference
+  Scenario: User can search for a BF complaint case by its case reference
     Given I am logged into "CS" as user "BF_USER"
     When I create a single "BF" case
     And I search for the case by its case reference
     Then the created case should be the only case visible in the search results
-
-#     HOCS-2847 HOCS-3161
-  @ComplaintsRegression
-  Scenario: COMP User sees the required information when viewing search
-    Given I am logged into "CS" as user "COMP_USER"
-    When I navigate to the "search" page
-    And I click the search button on the search page
-    Then the "COMP Search" workstack should contain only the expected columns
-
-  Scenario: User is able to select a COMP2 case reference from the escalate case column of a COMP case
-    Given I am logged into "CS" as user "COMP_USER"
-    When I create a "COMP2" case and move it to the "Stage 2 Registration" stage
-    And I navigate to the "Search" page
-    And I search for the COMP case escalated to COMP2 by it's case reference
-    And I load the COMP2 case by selecting its case reference from the Escalate Case column
-    Then the case should be loaded

--- a/src/test/resources/features/complaints/ComplaintsSend.feature
+++ b/src/test/resources/features/complaints/ComplaintsSend.feature
@@ -1,9 +1,11 @@
 @ComplaintsSend @Complaints
 Feature: Complaints Send
 
-#    HOCS-2722, HOCS-3076
+#     UKVI COMPLAINTS
+
+  # HOCS-2722, HOCS-3076
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can complete service send stage
+  Scenario: User can complete service send stage for a UKVI complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Send" stage
     And I load the current case
@@ -13,7 +15,7 @@ Feature: Complaints Send
     And the read-only Case Details accordion should contain all case information entered during the "Service Send" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can complete Ex-Gratia send stage
+  Scenario: User can complete Ex-Gratia send stage for a UKVI complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia Send" stage
     And I load the current case
@@ -23,7 +25,7 @@ Feature: Complaints Send
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia Send" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can complete Minor Misconduct send stage
+  Scenario: User can complete Minor Misconduct send stage for a UKVI complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct Send" stage
     And I load the current case
@@ -32,34 +34,8 @@ Feature: Complaints Send
     Then the case should be closed
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct Send" stage
 
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can complete the Send stage for an IEDET case
-    Given I am logged into "CS" as user "IEDET_USER"
-    When I create a "IEDET" case and move it to the "Send" stage
-    And I load the current case
-    And I select a Case Outcome
-    And I submit the Response details
-    Then the case should be closed
-
-  @ComplaintsPWorkflow @ComplaintsRegression
-  Scenario: User can complete the Send stage for an SMC case
-    Given I am logged into "CS" as user "SMC_USER"
-    When I get a "SMC" case at the "Send" stage
-    And I select a Case Outcome
-    And I submit the SMC Send stage
-    Then the case should be closed
-
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can complete the Send stage for a BF case
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Send" stage
-    And I select a Case Outcome
-    And I submit the Response details
-    Then the case should be closed
-    And the read-only Case Details accordion should contain all case information entered during the "Send draft response" stage
-
   @Validation
-  Scenario Outline: User tests the validation at the Service Send stage
+  Scenario Outline: User tests the validation for a UKVI complaint case at the Service Send stage
     When I create a "COMP" case and move it to the "Service Send" stage
     And I load and claim the current case
     And I trigger the "<errorType>" error message at the "Service Send" stage
@@ -69,3 +45,37 @@ Feature: Complaints Send
       | CASE OUTCOME REQUIRED     |
       | RESPONSE CHANNEL REQUIRED |
       | DATE OF RESPONSE REQUIRED |
+
+
+#     IEDET COMPLAINTS
+
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User can complete the Send stage for an IEDET complaint case
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to the "Send" stage
+    And I load the current case
+    And I select a Case Outcome
+    And I submit the Response details
+    Then the case should be closed
+
+
+#     SMC COMPLAINTS
+
+  @ComplaintsPWorkflow @ComplaintsRegression
+  Scenario: User can complete the Send stage for an SMC complaint case
+    Given I am logged into "CS" as user "SMC_USER"
+    When I get a "SMC" case at the "Send" stage
+    And I select a Case Outcome
+    And I submit the SMC Send stage
+    Then the case should be closed
+
+
+#     BF COMPLAINTS
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User can complete the Send stage for a BF complaint case
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Send" stage
+    And I select a Case Outcome
+    And I submit the Response details
+    Then the case should be closed
+    And the read-only Case Details accordion should contain all case information entered during the "Send draft response" stage

--- a/src/test/resources/features/complaints/ComplaintsTriage.feature
+++ b/src/test/resources/features/complaints/ComplaintsTriage.feature
@@ -1,10 +1,11 @@
 @ComplaintsTriage @Complaints
 Feature: Complaints Triage
 
-#    Expected intermittent failure for Minor Misconduct example. Defect HOCS-4309 raised.
-#  HOCS-2944, HOCS-2868
+#     UKVI COMPLAINTS
+
+  # HOCS-2944, HOCS-2868
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario Outline: User can transfer a case COMP case to CCH
+  Scenario Outline: User can transfer a Stage 1 UKVI complaint case back to CCH
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "<complaintType> Triage" stage
     And I load and claim the current case
@@ -20,9 +21,9 @@ Feature: Complaints Triage
       | Minor Misconduct |
       | Ex-Gratia        |
 
-#    HOCS-2979, HOCS-3074, HOCS-2868, HOCS-2869, HOCS-3002, HOCS-2913
+  # HOCS-2979, HOCS-3074, HOCS-2868, HOCS-2869, HOCS-3002, HOCS-2913
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User completes the Service Triage stage
+  Scenario: User completes the Service Triage stage for a UKVI complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
@@ -36,7 +37,7 @@ Feature: Complaints Triage
     And the read-only Case Details accordion should contain all case information entered during the "Service Triage" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User completes the Ex-Gratia Triage stage
+  Scenario: User completes the Ex-Gratia Triage stage for a UKVI complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia Triage" stage
     And I load and claim the current case
@@ -51,7 +52,7 @@ Feature: Complaints Triage
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia Triage" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User completes the Minor Misconduct Triage stage
+  Scenario: User completes the Minor Misconduct Triage stage for a UKVI complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct Triage" stage
     And I load and claim the current case
@@ -66,45 +67,9 @@ Feature: Complaints Triage
     And the summary should display the owning team as "Minor Misconduct"
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct Triage" stage
 
+  # HOCS-3028
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User completes the Triage stage for an IEDET case
-    Given I am logged into "CS" as user "IEDET_USER"
-    When I create a "IEDET" case and move it to the "Triage" stage
-    And I load and claim the current case
-    And I select the "Transferred to Third Party Supplier" action for an IEDET case at the Triage stage
-    And I submit details on the Triage Capture Reason page
-    Then the case should be moved to the "Draft" stage
-    And the summary should display the owning team as "IE Detention"
-    And the read-only Case Details accordion should contain all case information entered during the "Triage" stage
-
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User completes the Triage stage for an SMC case
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Triage" stage
-    And I load and claim the current case
-    And I accept the case at Triage stage
-    And I enter details on PSU Reference page
-    And I accept the previous Claim Category selection
-    And I accept the previous Case Details selection
-    And I submit details on the Triage Capture Reason page
-    And I send the case to drafting
-    And I load the current case
-    And the summary should display the owning team as "Serious Misconduct"
-    And the read-only Case Details accordion should contain all case information entered during the "Triage" stage
-
-  @ComplaintsRegression @ComplaintsWorkflow
-  Scenario: User completes the Case Triage stage for a BF case
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Triage" stage
-    And I submit details on the Triage Capture Reason page
-    And I send the case to drafting
-    Then the case should be moved to the "DRAFT" stage
-    And the summary should display the owning team as "Border Force"
-    And the read-only Case Details accordion should contain all case information entered during the "Case Triage" stage
-
-#    HOCS-3028
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can escalate a case at Service Triage stage
+  Scenario: User can escalate a UKVI complaint case at Service Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
@@ -119,7 +84,7 @@ Feature: Complaints Triage
     And the read-only Case Details accordion should contain all case information entered during the "Service Triage" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can escalate a case at Ex-Gratia Triage stage
+  Scenario: User can escalate a UKVI complaint case at Ex-Gratia Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia Triage" stage
     And I load and claim the current case
@@ -134,7 +99,7 @@ Feature: Complaints Triage
     And an Escalation note should be visible in the timeline showing the submitted reason for the cases escalation
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can escalate a case at Minor Misconduct Triage stage
+  Scenario: User can escalate a UKVI complaint case at Minor Misconduct Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct Triage" stage
     And I load and claim the current case
@@ -149,20 +114,9 @@ Feature: Complaints Triage
     And the summary should display the owning team as "Minor Misconduct"
     And an Escalation note should be visible in the timeline showing the submitted reason for the cases escalation
 
+  # HOCS-3026
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User is able to escalate a BF case to workflow manager at the Case Triage stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Triage" stage
-    And I submit details on the Triage Capture Reason page
-    And I escalate the case to WFM at Triage stage
-    Then the case should be moved to the "Escalated to WFM" stage
-    And the summary should display the owning team as "Border Force"
-    And an Escalation note should be visible in the timeline showing the submitted reason for the cases escalation
-    And the read-only Case Details accordion should contain all case information entered during the "Case Triage" stage
-
-#    HOCS-3026
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can hard close a case at Service Triage stage
+  Scenario: User can hard close a UKVI complaint case at Service Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
@@ -179,7 +133,7 @@ Feature: Complaints Triage
     And the read-only Case Details accordion should contain all case information entered during the "Service Triage" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can hard close a case at Ex-Gratia Triage stage
+  Scenario: User can hard close a UKVI complaint case at Ex-Gratia Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Ex-Gratia Triage" stage
     And I load and claim the current case
@@ -197,7 +151,7 @@ Feature: Complaints Triage
     And the read-only Case Details accordion should contain all case information entered during the "Ex-Gratia Triage" stage
 
   @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can hard close a case at Minor Misconduct Triage stage
+  Scenario: User can hard close a UKVI complaint case at Minor Misconduct Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Minor Misconduct Triage" stage
     And I load and claim the current case
@@ -215,48 +169,9 @@ Feature: Complaints Triage
     And a Case closure note should be visible in the timeline showing the submitted reason for closing the case
     And the read-only Case Details accordion should contain all case information entered during the "Minor Misconduct Triage" stage
 
+  # HOCS-2870, HOCS-3096, HOCS-3022
   @ComplaintsRegression
-  Scenario: User can close an IEDET case at the Triage stage
-    Given I am logged into "CS" as user "IEDET_USER"
-    When I create a "IEDET" case and move it to the "Triage" stage
-    And I load and claim the current case
-    And I select the "No Further Consideration" action for an IEDET case at the Triage stage
-    Then the case should be closed
-
-  @ComplaintsRegression
-  Scenario: User can hard close a BF case at the Triage stage
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Triage" stage
-    And I submit details on the Triage Capture Reason page
-    And I select to complete the case at Triage
-    And I click the "Continue" button
-    And I enter a reason for closing the case
-    Then the case should be closed
-    And the read-only Case Details accordion should contain all case information entered during the "Case Triage" stage
-
-#    Expected failure. Defect HOCS-3980 raised.
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can transfer a SMC case from Triage to CCH
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Triage" stage
-    And I load and claim the current case
-    And I select to Transfer the complaint
-    And I enter a reason for "CCH" transfer and continue
-    Then the case should be closed
-
-#    Expected failure. Defect HOCS-3980 raised.
-  @ComplaintsWorkflow @ComplaintsRegression
-  Scenario: User can transfer a SMC case from Triage to IEDET
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Triage" stage
-    And I load and claim the current case
-    And I select to Transfer the complaint
-    And I enter a reason for "IE Detention" transfer and continue
-    Then the case should be closed
-
-#    HOCS-2870, HOCS-3096, HOCS-3022
-  @ComplaintsRegression
-  Scenario Outline: User can add and complete or cancel contributions to COMP cases as part of Service Triage stage
+  Scenario Outline: User can add and complete or cancel contributions to UKVI complaint cases as part of Service Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
@@ -274,24 +189,9 @@ Feature: Complaints Triage
       | Business         | Complete |
       | Business         | Cancel   |
 
+  # HOCS-3103
   @ComplaintsRegression
-  Scenario Outline: User can add and complete or cancel contributions to BF cases as part of Case Triage
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF" case at the "Triage" stage
-    And I submit details on the Triage Capture Reason page
-    And I add a "<contributionType>" contribution request
-    And I "<action>" the contribution request
-    Then the "<contributionType>" contribution request should be marked as "<action>"
-    Examples:
-    | contributionType  | action    |
-    | Complainant       | Complete  |
-    | Complainant       | Cancel    |
-    | Business          | Complete  |
-    | Business          | Cancel    |
-
-#    HOCS-3103
-  @ComplaintsRegression
-  Scenario: User can tell if a contribution is overdue on the Triage Contributions page
+  Scenario: User can tell if a contribution to a UKVI complaint case is overdue on the Triage Contributions page
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
@@ -303,9 +203,9 @@ Feature: Complaints Triage
     Then the "complainant" contribution request should be marked as "overdue"
     And the overdue contribution request should be highlighted
 
-#    HOCS-2979
+  # HOCS-2979
   @ComplaintsRegression
-  Scenario: User can select that a Letter of Authority is required for this complaint
+  Scenario: User can select that a Letter of Authority is required for a UKVI complaint case
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
@@ -320,7 +220,7 @@ Feature: Complaints Triage
     And the read-only Case Details accordion should contain all case information entered during the "Service Triage" stage
 
   @Validation
-  Scenario Outline: User tests the validation at the Service Triage stage
+  Scenario Outline: User tests the validation for a UKVI complaint case at the Service Triage stage
     Given I am logged into "CS" as user "COMP_USER"
     When I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
@@ -338,3 +238,113 @@ Feature: Complaints Triage
       | ESCALATION REASON REQUIRED                        |
       | COMPLETE CASE NOTE REQUIRED                       |
       | COMPLETE CASE PERMANENTLY RESPONSE REQUIRED       |
+
+
+#     IEDET COMPLAINTS
+
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User completes the Triage stage for an IEDET complaint case
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to the "Triage" stage
+    And I load and claim the current case
+    And I select the "Transferred to Third Party Supplier" action for an IEDET case at the Triage stage
+    And I submit details on the Triage Capture Reason page
+    Then the case should be moved to the "Draft" stage
+    And the summary should display the owning team as "IE Detention"
+    And the read-only Case Details accordion should contain all case information entered during the "Triage" stage
+
+  @ComplaintsRegression
+  Scenario: User can close an IEDET complaint case at the Triage stage
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to the "Triage" stage
+    And I load and claim the current case
+    And I select the "No Further Consideration" action for an IEDET case at the Triage stage
+    Then the case should be closed
+
+
+#     SMC COMPLAINTS
+
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User completes the Triage stage for an SMC complaint case
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Triage" stage
+    And I load and claim the current case
+    And I accept the case at Triage stage
+    And I enter details on PSU Reference page
+    And I accept the previous Claim Category selection
+    And I accept the previous Case Details selection
+    And I submit details on the Triage Capture Reason page
+    And I send the case to drafting
+    And I load the current case
+    And the summary should display the owning team as "Serious Misconduct"
+    And the read-only Case Details accordion should contain all case information entered during the "Triage" stage
+
+  # Expected failure. Defect HOCS-3980 raised.
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User can transfer a SMC complaint case to a UKVI complaint case at Triage stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Triage" stage
+    And I load and claim the current case
+    And I select to Transfer the complaint
+    And I enter a reason for "CCH" transfer and continue
+    Then the case should be closed
+
+  # Expected failure. Defect HOCS-3980 raised.
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User can transfer a SMC complaint case to an IEDET complaint case at Triage stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Triage" stage
+    And I load and claim the current case
+    And I select to Transfer the complaint
+    And I enter a reason for "IE Detention" transfer and continue
+    Then the case should be closed
+
+
+#     BF COMPLAINTS
+
+  @ComplaintsRegression @ComplaintsWorkflow
+  Scenario: User completes the Case Triage stage for a BF complaint case
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Triage" stage
+    And I submit details on the Triage Capture Reason page
+    And I send the case to drafting
+    Then the case should be moved to the "DRAFT" stage
+    And the summary should display the owning team as "Border Force"
+    And the read-only Case Details accordion should contain all case information entered during the "Case Triage" stage
+
+  @ComplaintsWorkflow @ComplaintsRegression
+  Scenario: User is able to escalate a BF complaint case to workflow manager at the Case Triage stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Triage" stage
+    And I submit details on the Triage Capture Reason page
+    And I escalate the case to WFM at Triage stage
+    Then the case should be moved to the "Escalated to WFM" stage
+    And the summary should display the owning team as "Border Force"
+    And an Escalation note should be visible in the timeline showing the submitted reason for the cases escalation
+    And the read-only Case Details accordion should contain all case information entered during the "Case Triage" stage
+
+  @ComplaintsRegression
+  Scenario: User can hard close a BF complaint case at the Triage stage
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Triage" stage
+    And I submit details on the Triage Capture Reason page
+    And I select to complete the case at Triage
+    And I click the "Continue" button
+    And I enter a reason for closing the case
+    Then the case should be closed
+    And the read-only Case Details accordion should contain all case information entered during the "Case Triage" stage
+
+  @ComplaintsRegression
+  Scenario Outline: User can add and complete or cancel contributions to BF complaint cases as part of Case Triage
+    Given I am logged into "CS" as user "BF_USER"
+    When I get a "BF" case at the "Triage" stage
+    And I submit details on the Triage Capture Reason page
+    And I add a "<contributionType>" contribution request
+    And I "<action>" the contribution request
+    Then the "<contributionType>" contribution request should be marked as "<action>"
+    Examples:
+    | contributionType  | action    |
+    | Complainant       | Complete  |
+    | Complainant       | Cancel    |
+    | Business          | Complete  |
+    | Business          | Cancel    |

--- a/src/test/resources/features/complaints/ComplaintsWorkstacks.feature
+++ b/src/test/resources/features/complaints/ComplaintsWorkstacks.feature
@@ -1,9 +1,11 @@
 @ComplaintsWorkstacks @Complaints
 Feature: Complaints Workstacks
 
-#     HOCS-2865, HOCS-3161
+#     UKVI COMPLAINTS
+
+  # HOCS-2865, HOCS-3161
   @ComplaintsRegression
-  Scenario Outline: COMP User sees the required information when viewing a workstack
+  Scenario Outline: UKVI complaints user sees the required information when viewing a workstack
     Given I am logged into "CS" as user "COMP_USER"
     And I enter the "<workstack>" workstack
     Then the "<workstack>" workstack should contain only the expected columns
@@ -15,51 +17,7 @@ Feature: Complaints Workstacks
       | CCT Triage             |
 
   @ComplaintsRegression
-  Scenario: IEDET User sees the required information when viewing a workstack
-    Given I am logged into "CS" as user "IEDET_USER"
-    And I enter the "IE Detention" workstack
-    Then the "IE Detention" workstack should contain only the expected columns
-
-  @ComplaintsRegression
-  Scenario: Serious Misconduct user sees the required information when viewing a workstack
-    Given I am logged into "CS" as user "SMC_USER"
-    And I enter the "Serious Misconduct" workstack
-    Then the "Serious Misconduct" workstack should contain only the expected columns
-
-  @ComplaintsRegression
-  Scenario: User can see the required information when viewing the BF workstack
-    Given I am logged into "CS" as user "BF_USER"
-    And I enter a "Border Force" workstack
-    Then the "Border Force" workstack should contain only the expected columns
-
-#     HOCS-3076 HOCS-3161 HOCS-4006
-  @ComplaintsRegression
-  Scenario Outline: User is able to see a yellow highlighted deadline on a complaint case that is close to its deadline date
-    Given I am logged into "CS" as user "<caseType>_USER"
-    When I create a single "<caseType>" case with the correspondence received date set <amountOfDays> workdays ago
-    And I click to view the case in the "<workstack>" workstack
-    Then the case deadline should be highlighted "yellow"
-    Examples:
-      | caseType | amountOfDays | workstack              |
-      | COMP     | 15           | Complaint Registration |
-      | IEDET    | 15           | IE Detention           |
-      | SMC      | 55           | Serious Misconduct     |
-
-#     HOCS-3076 HOCS-3161 HOCS-4006
-  @ComplaintsRegression
-  Scenario Outline: User is able to see a red highlighted deadline on an complaint case that is past its deadline date
-    Given I am logged into "CS" as user "<caseType>_USER"
-    When I create a single "<caseType>" case with the correspondence received date set <amountOfDays> workdays ago
-    And I click to view the case in the "<workstack>" workstack
-    Then the case deadline should be highlighted "red"
-    Examples:
-      | caseType | amountOfDays | workstack              |
-      | COMP     | 21           | Complaint Registration |
-      | IEDET    | 21           | IE Detention           |
-      | SMC      | 61           | Serious Misconduct     |
-
-  @ComplaintsRegression
-  Scenario: As a COMP user, when I view cases in a workstack, I want to be able to tell if a case has an overdue contribution request
+  Scenario: As a UKVI complaints user, when I view cases in a workstack, I want to be able to tell if a case has an overdue contribution request
     Given I am logged into "CS" as user "COMP_USER"
     And I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
@@ -76,7 +34,7 @@ Feature: Complaints Workstacks
     Then I should be able to tell that the case has an overdue contribution
 
   @ComplaintsRegression
-  Scenario: As a COMP user, when I view cases in a workstack, I want to be able to tell if a case has a due contribution request
+  Scenario: As a UKVI complaints user, when I view cases in a workstack, I want to be able to tell if a case has a due contribution request
     Given I am logged into "CS" as user "COMP_USER"
     And I create a "COMP" case and move it to the "Service Triage" stage
     And I load and claim the current case
@@ -89,3 +47,59 @@ Feature: Complaints Workstacks
     Then the displayed contribution request status of the case should be correct
     And I view the "My Cases" workstack
     Then I should be able to tell when the contribution request is due
+
+
+#     IEDET COMPLAINTS
+
+  @ComplaintsRegression
+  Scenario: IEDET complaints user sees the required information when viewing a workstack
+    Given I am logged into "CS" as user "IEDET_USER"
+    And I enter the "IE Detention" workstack
+    Then the "IE Detention" workstack should contain only the expected columns
+
+
+#     SMC COMPLAINTS
+
+  @ComplaintsRegression
+  Scenario: Serious Misconduct complaints user sees the required information when viewing a workstack
+    Given I am logged into "CS" as user "SMC_USER"
+    And I enter the "Serious Misconduct" workstack
+    Then the "Serious Misconduct" workstack should contain only the expected columns
+
+
+#     BF COMPLAINTS
+
+  @ComplaintsRegression
+  Scenario: Border Force complaints user can see the required information when viewing a workstack
+    Given I am logged into "CS" as user "BF_USER"
+    And I enter a "Border Force" workstack
+    Then the "Border Force" workstack should contain only the expected columns
+
+
+#     ALL COMPLAINTS
+
+  # HOCS-3076 HOCS-3161 HOCS-4006
+  @ComplaintsRegression
+  Scenario Outline: Complaints user is able to see a yellow highlighted deadline on a complaint case that is close to its deadline date
+    Given I am logged into "CS" as user "<caseType>_USER"
+    When I create a single "<caseType>" case with the correspondence received date set <amountOfDays> workdays ago
+    And I click to view the case in the "<workstack>" workstack
+    Then the case deadline should be highlighted "yellow"
+    Examples:
+      | caseType | amountOfDays | workstack              |
+      | COMP     | 15           | Complaint Registration |
+      | IEDET    | 15           | IE Detention           |
+      | SMC      | 55           | Serious Misconduct     |
+
+  # HOCS-3076 HOCS-3161 HOCS-4006
+  @ComplaintsRegression
+  Scenario Outline: Complaints user is able to see a red highlighted deadline on an complaint case that is past its deadline date
+    Given I am logged into "CS" as user "<caseType>_USER"
+    When I create a single "<caseType>" case with the correspondence received date set <amountOfDays> workdays ago
+    And I click to view the case in the "<workstack>" workstack
+    Then the case deadline should be highlighted "red"
+    Examples:
+      | caseType | amountOfDays | workstack              |
+      | COMP     | 21           | Complaint Registration |
+      | IEDET    | 21           | IE Detention           |
+      | SMC      | 61           | Serious Misconduct     |

--- a/src/test/resources/features/complaints/Superuser.feature
+++ b/src/test/resources/features/complaints/Superuser.feature
@@ -2,13 +2,13 @@
 Feature: Superuser
 
   @ComplaintsRegression
-  Scenario: A Complaints Admin User can complete the COMP workflow
+  Scenario: A Complaints Admin User can complete the UKVI stage 1 complaint workflow
     Given I log in to "CS" as user "COMP_SUPERUSER"
     When I create a "COMP" case and move it to "COMPLAINT CLOSED"
     Then the case should be closed
 
   @ComplaintsRegression
-  Scenario: A Complaints Admin User can complete a stage whilst case is owned by another user
+  Scenario: A Complaints Admin User can complete a stage of the UKVI stage 1 workflow whilst the case is owned by another user
     Given I log in to "CS" as user "COMP_USER"
     And I create a single "COMP" case
     When I allocate the case to myself via the successful case creation screen

--- a/src/test/resources/features/to/DataInput.feature
+++ b/src/test/resources/features/to/DataInput.feature
@@ -24,6 +24,7 @@ Feature: Data Input
   Scenario: As a Data Input user, I want to be able to enter the intended recipient, so the reply can be correctly personalised
     And I select which business area the correspondence is for
     And I select which channel the correspondence was received by
+    And I select whether the Home Secretary has an interest in the case
     And I add a "Third Party Representative" correspondent
     And I confirm the primary correspondent
     When I add a Recipient to the case


### PR DESCRIPTION
Removed unnecessary steps from BF Complaint Registration scenario.
Removed unnecessary methods from BF complete Registration stage method.
Changed complaint scenario titles to make it clearer which complaints case type the scenario was testing, and structured the feature files by case type.
Tided up BFProgressCase file.
Tidied up End to End feature into different complaint types.