### PR TITLE
Amendments for faster creation of stage 2 cases

### DIFF
--- a/src/test/java/com/hocs/test/glue/decs/CreateCaseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/CreateCaseStepDefs.java
@@ -7,6 +7,7 @@ import static net.serenitybdd.core.Serenity.setSessionVariable;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.hocs.test.pages.complaints.BFProgressCase;
 import com.hocs.test.pages.complaints.COMPProgressCase;
 import com.hocs.test.pages.dcu.DCUProgressCase;
 import com.hocs.test.pages.decs.Correspondents;
@@ -42,6 +43,8 @@ public class CreateCaseStepDefs extends BasePage {
 
     COMPProgressCase compProgressCase;
 
+    BFProgressCase bfProgressCase;
+
     DataInput dataInput;
 
     Dashboard dashboard;
@@ -65,7 +68,10 @@ public class CreateCaseStepDefs extends BasePage {
             waitFor(wcsRegistration.registrationSchemeCheckTitle);
         } else {
             if (caseType.equalsIgnoreCase("COMP2")) {
-                compProgressCase.escalateACOMPCaseToCOMP2();
+                compProgressCase.escalateAStage1CaseToStage2();
+            }
+            if (caseType.equals("BF2")) {
+                bfProgressCase.escalateAStage1CaseToStage2();
             }
             createCase.createCSCaseOfType(caseType.toUpperCase());
         }

--- a/src/test/java/com/hocs/test/glue/decs/DocumentsStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/DocumentsStepDefs.java
@@ -54,7 +54,7 @@ public class DocumentsStepDefs extends BasePage {
     public void iManageTheDocumentsOfANewUKVIComplaintsCase() {
         String caseType = createCase.getRandomComplaintsCaseType();
         if (caseType.equalsIgnoreCase("COMP2")) {
-            compProgressCase.escalateACOMPCaseToCOMP2();
+            compProgressCase.escalateAStage1CaseToStage2();
         }
         createCase.createCSCaseOfType(caseType);
         confirmationScreens.goToCaseFromConfirmationScreen();

--- a/src/test/java/com/hocs/test/glue/decs/ManagementUIStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/ManagementUIStepDefs.java
@@ -635,7 +635,7 @@ public class ManagementUIStepDefs extends BasePage {
     @And("I enter the (cases )reference, a valid withdrawal date and text into the note field")
     public void iEnterTheCasesReferenceAValidWithdrawalDateAndTextIntoTheNoteField() {
         withdrawACase.enterCaseReference(getCurrentCaseReference());
-        withdrawACase.enterWithdrawalDate();
+        withdrawACase.enterWithdrawalDate(getTodaysDate());
         withdrawACase.enterWithdrawalNotes("Test withdrawal notes");
     }
 

--- a/src/test/java/com/hocs/test/pages/complaints/BFProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/complaints/BFProgressCase.java
@@ -69,7 +69,7 @@ public class BFProgressCase extends BasePage {
             getStage1CaseEligibleForEscalation();
         }
         escalateEligibleStage1CaseToStage2();
-        setSessionVariable("caseType").to("COMP2");
+        setSessionVariable("caseType").to("BF2");
         waitABit(500);
     }
 

--- a/src/test/java/com/hocs/test/pages/complaints/BFProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/complaints/BFProgressCase.java
@@ -14,7 +14,6 @@ import com.hocs.test.pages.decs.Documents;
 import com.hocs.test.pages.decs.RecordCaseData;
 import com.hocs.test.pages.decs.Search;
 import net.serenitybdd.core.pages.WebElementFacade;
-import org.junit.Assert;
 
 public class BFProgressCase extends BasePage {
 
@@ -48,7 +47,7 @@ public class BFProgressCase extends BasePage {
         String precedingStage = getStageThatPrecedesTargetStage(targetStage);
         if (precedingStage.equals("CREATE NEW CASE")) {
             if (caseType.equals("BF2")) {
-                escalateABFCaseToBF2();
+                escalateAStage1CaseToStage2();
             }
             createCase.createCSCaseOfType(caseType);
             dashboard.goToDashboard();
@@ -65,35 +64,42 @@ public class BFProgressCase extends BasePage {
         moveCaseOfTypeFromCurrentStageToTargetStage(caseType, "N/A", targetStage);
     }
 
-    public void attemptEscalateBFCaseToStage2() throws Exception {
+    public void escalateAStage1CaseToStage2() {
+        if (!checkIfRandomStage1CaseEligibleForEscalationCanBeFound()) {
+            getStage1CaseEligibleForEscalation();
+        }
+        escalateEligibleStage1CaseToStage2();
+        setSessionVariable("caseType").to("COMP2");
+        waitABit(500);
+    }
+
+    private boolean checkIfRandomStage1CaseEligibleForEscalationCanBeFound() {
         dashboard.selectSearchLinkFromMenuBar();
+        if (checkboxWithLabelIsCurrentlyVisible("Border Force Case")) {
+            checkSpecificCheckbox("Border Force Case");
+        }
         search.enterComplaintsSearchCriteria("Complainant Home Office Reference", getCurrentMonth() + "/" + getCurrentYear());
         search.clickTheButton("Search");
         search.waitForResultsPage();
-        if (search.checkVisibilityOfEscalationHypertext()) {
-            WebElementFacade bfCaseRefField = findBy("//a[contains(text(), 'Escalate case')]/parent::td/preceding-sibling::td/a");
-            String bfCaseRef = bfCaseRefField.getText();
-            setSessionVariable("stage2CaseReference").to(bfCaseRef);
-            System.out.print("Case reference of case being escalated: " + bfCaseRef + "\n");
-            search.clickEscalateComplaintsCaseToStage2();
-        } else {
-            throw new Exception("Escalation hypertext not visible");
-        }
+        return search.checkVisibilityOfEscalationHypertext();
     }
 
-    public void escalateABFCaseToBF2() {
-        try {
-            attemptEscalateBFCaseToStage2();
-        } catch (Exception a) {
-            moveCaseOfTypeFromCurrentStageToTargetStage("BF", "N/A", "CLOSED");
-            try {
-                attemptEscalateBFCaseToStage2();
-            } catch (Exception e) {
-                Assert.fail("Escalation hypertext not visible on retry");
-            }
+    private void getStage1CaseEligibleForEscalation() {
+        createCase.createAndWithDrawACSCaseOfType("BF");
+        dashboard.selectSearchLinkFromMenuBar();
+        if (checkboxWithLabelIsCurrentlyVisible("Border Force Case")) {
+            checkSpecificCheckbox("Border Force Case");
         }
-        setSessionVariable("caseType").to("BF2");
-        waitABit(500);
+        search.searchByCaseReference(getCurrentCaseReference());
+        search.waitForResultsPage();
+    }
+
+    private void escalateEligibleStage1CaseToStage2() {
+        WebElementFacade bfCaseRefField = findBy("//a[contains(text(), 'Escalate case')]/parent::td/preceding-sibling::td/a");
+        String bfCaseRef = bfCaseRefField.getText();
+        setSessionVariable("stage2CaseReference").to(bfCaseRef);
+        System.out.print("Case reference of case being escalated: " + bfCaseRef + "\n");
+        search.clickEscalateComplaintsCaseToStage2();
     }
 
     private String getStageThatPrecedesTargetStage(String targetStage) {

--- a/src/test/java/com/hocs/test/pages/decs/BasePage.java
+++ b/src/test/java/com/hocs/test/pages/decs/BasePage.java
@@ -623,6 +623,12 @@ public class BasePage extends PageObject {
         safeClickOn(checkbox);
     }
 
+    public boolean checkboxWithLabelIsCurrentlyVisible(String checkboxLabelText) {
+        WebElementFacade checkbox =
+                findBy("//input[@type='checkbox']/following-sibling::label[text()=" + sanitiseXpathAttributeString(checkboxLabelText) + "]");
+        return  checkbox.isCurrentlyVisible();
+    }
+
     // Typeaheads
 
     public String selectRandomOptionFromTypeaheadWithHeading(String headingText) {

--- a/src/test/java/com/hocs/test/pages/decs/CreateCase.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase.java
@@ -8,6 +8,7 @@ import static net.serenitybdd.core.Serenity.setSessionVariable;
 import com.hocs.test.pages.complaints.COMPProgressCase;
 import com.hocs.test.pages.complaints.Registration;
 import com.hocs.test.pages.dcu.DCUProgressCase;
+import com.hocs.test.pages.managementUI.MUI;
 import com.hocs.test.pages.mpam.Creation;
 import com.hocs.test.pages.mpam.MPAMProgressCase;
 import com.hocs.test.pages.mpam.MTSDataInput;
@@ -39,6 +40,10 @@ public class CreateCase extends BasePage {
     RecordCaseData recordCaseData;
 
     Correspondents correspondents;
+
+    MUI mui;
+
+    LoginPage loginPage;
 
     // Elements
 
@@ -334,6 +339,12 @@ public class CreateCase extends BasePage {
         clickTheButton("Create claim");
         setSessionVariable("caseType").to("WCS");
         setCaseReferenceFromAssignedCase();
+    }
+
+    public void createAndWithDrawACSCaseOfType(String caseType) {
+        createCSCaseOfType(caseType);
+        mui.withdrawACaseInMUI(getCurrentCaseReference());
+        loginPage.navigateToCS();
     }
 
     public void clearCorrespondentReceivedDateFields() {

--- a/src/test/java/com/hocs/test/pages/decs/CreateCase.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase.java
@@ -5,13 +5,7 @@ import static net.serenitybdd.core.Serenity.pendingStep;
 import static net.serenitybdd.core.Serenity.sessionVariableCalled;
 import static net.serenitybdd.core.Serenity.setSessionVariable;
 
-import com.hocs.test.pages.complaints.COMPProgressCase;
-import com.hocs.test.pages.complaints.Registration;
-import com.hocs.test.pages.dcu.DCUProgressCase;
 import com.hocs.test.pages.managementUI.MUI;
-import com.hocs.test.pages.mpam.Creation;
-import com.hocs.test.pages.mpam.MPAMProgressCase;
-import com.hocs.test.pages.mpam.MTSDataInput;
 
 import config.User;
 import java.text.DateFormat;

--- a/src/test/java/com/hocs/test/pages/decs/Dashboard.java
+++ b/src/test/java/com/hocs/test/pages/decs/Dashboard.java
@@ -105,6 +105,7 @@ public class Dashboard extends BasePage {
 
     public void selectSearchLinkFromMenuBar() {
         safeClickOn(searchLink);
+        waitForPageWithTitle("Search");
     }
 
     public void selectCreateSingleCaseLinkFromMenuBar() {

--- a/src/test/java/com/hocs/test/pages/decs/LoginPage.java
+++ b/src/test/java/com/hocs/test/pages/decs/LoginPage.java
@@ -26,7 +26,13 @@ public class LoginPage extends BasePage {
 
     //Basic methods
 
-    public boolean onLoginPage() { return isElementDisplayed(usernameField);}
+    public void navigateToCS() {
+        open();
+    }
+
+    public boolean onLoginPage() {
+        return isElementDisplayed(usernameField);
+    }
 
     public void enterUsername(String username) {
         usernameField.sendKeys(username);

--- a/src/test/java/com/hocs/test/pages/decs/Search.java
+++ b/src/test/java/com/hocs/test/pages/decs/Search.java
@@ -390,6 +390,12 @@ public class Search extends BasePage {
         }
     }
 
+    public void searchByCaseReference(String caseReference) {
+        enterSpecificTextIntoTextFieldWithHeading(caseReference, "Case reference");
+        safeClickOn(searchButton);
+    }
+
+
     public void searchBySubstringOfCaseReference() {
         int n = 0;
         String substring = null;
@@ -419,8 +425,7 @@ public class Search extends BasePage {
         }
         String randomCaseRefString = "/012" + randomCaseIntToString;
         setSessionVariable("caseReferenceSubstring").to(randomCaseRefString);
-        caseReferenceSearchBox.sendKeys(randomCaseRefString);
-        safeClickOn(searchButton);
+        searchByCaseReference(randomCaseRefString);
     }
 
     public boolean checkVisibilityOfEscalationHypertext() {
@@ -897,28 +902,32 @@ public class Search extends BasePage {
                 String searchCorrespondentFullName = sessionVariableCalled("searchCorrespondentFullName");
                 safeClickOn(randomSearchResultHypertext);
                 peopleTab.selectPeopleTab();
-                WebElementFacade primaryCorrespondentFullName = findBy("//h2[text()='Correspondent (primary)']/following-sibling::table//th[text()='Name']/following-sibling::td");
+                WebElementFacade primaryCorrespondentFullName = findBy(
+                        "//h2[text()='Correspondent (primary)']/following-sibling::table//th[text()='Name']/following-sibling::td");
                 primaryCorrespondentFullName.shouldContainText(searchCorrespondentFullName);
                 break;
             case "CORRESPONDENT POSTCODE":
                 String searchCorrespondentPostcode = sessionVariableCalled("searchCorrespondentPostcode");
                 safeClickOn(randomSearchResultHypertext);
                 peopleTab.selectPeopleTab();
-                WebElementFacade primaryCorrespondentPostcode = findBy("//h2[text()='Correspondent (primary)']/following-sibling::table//th[text()='Address']/following-sibling::td/span[4]");
+                WebElementFacade primaryCorrespondentPostcode = findBy(
+                        "//h2[text()='Correspondent (primary)']/following-sibling::table//th[text()='Address']/following-sibling::td/span[4]");
                 primaryCorrespondentPostcode.shouldContainText(searchCorrespondentPostcode);
                 break;
             case "CORRESPONDENT EMAIL ADDRESS":
                 String searchCorrespondentEmailAddress = sessionVariableCalled("searchCorrespondentEmailAddress");
                 safeClickOn(randomSearchResultHypertext);
                 peopleTab.selectPeopleTab();
-                WebElementFacade primaryCorrespondentEmailAddress = findBy("//h2[text()='Correspondent (primary)']/following-sibling::table//th[text()='Email address']/following-sibling::td");
+                WebElementFacade primaryCorrespondentEmailAddress = findBy(
+                        "//h2[text()='Correspondent (primary)']/following-sibling::table//th[text()='Email address']/following-sibling::td");
                 primaryCorrespondentEmailAddress.shouldContainText(searchCorrespondentEmailAddress);
                 break;
             case "CORRESPONDENT REFERENCE NUMBER":
                 String searchCorrespondentReferenceNumber = sessionVariableCalled("searchCorrespondentReferenceNumber");
                 safeClickOn(randomSearchResultHypertext);
                 peopleTab.selectPeopleTab();
-                WebElementFacade primaryCorrespondentReferenceNumber = findBy("//h2[text()='Correspondent (primary)']/following-sibling::table//th[text()='Reference']/following-sibling::td");
+                WebElementFacade primaryCorrespondentReferenceNumber = findBy(
+                        "//h2[text()='Correspondent (primary)']/following-sibling::table//th[text()='Reference']/following-sibling::td");
                 primaryCorrespondentReferenceNumber.shouldContainText(searchCorrespondentReferenceNumber);
                 break;
             case "ACTIVE CASES ONLY":

--- a/src/test/java/com/hocs/test/pages/managementUI/MUI.java
+++ b/src/test/java/com/hocs/test/pages/managementUI/MUI.java
@@ -1,0 +1,19 @@
+package com.hocs.test.pages.managementUI;
+
+import com.hocs.test.pages.MuiLoginPage;
+import com.hocs.test.pages.decs.BasePage;
+
+public class MUI extends BasePage {
+
+    MuiLoginPage muiLoginPage;
+
+    MUIDashboard muiDashboard;
+
+    WithdrawACase withdrawACase;
+
+    public void withdrawACaseInMUI(String caseReference) {
+        muiLoginPage.open();
+        muiDashboard.selectDashboardLinkWithText("Withdraw a case");
+        withdrawACase.withdrawACase(caseReference, getTodaysDate(), "Withdrawn for stage 2 case creation");
+    }
+}

--- a/src/test/java/com/hocs/test/pages/managementUI/WithdrawACase.java
+++ b/src/test/java/com/hocs/test/pages/managementUI/WithdrawACase.java
@@ -27,12 +27,20 @@ public class WithdrawACase extends BasePage {
         typeInto(caseReferenceTextField, caseReference);
     }
 
-    public void enterWithdrawalDate() {
-        typeIntoDateFields(withdrawalDateDayTextbox, withdrawalDateMonthTextbox, withdrawalDateYearTextbox, getTodaysDate());
+    public void enterWithdrawalDate(String date) {
+        enterDateIntoDateFieldsWithHeading(date, "Withdrawal Date");
     }
 
     public void enterWithdrawalNotes(String notes) {
         typeInto(notesTextArea, notes);
         setSessionVariable("withdrawalNotes").to(notes);
+    }
+
+    public void withdrawACase(String caseReference, String date, String withdrawalNotes) {
+        enterCaseReference(caseReference);
+        enterWithdrawalDate(date);
+        enterWithdrawalNotes(withdrawalNotes);
+        clickTheButton("Withdraw");
+        waitABit(500);
     }
 }

--- a/src/test/resources/features/cs/CreateCase.feature
+++ b/src/test/resources/features/cs/CreateCase.feature
@@ -3,7 +3,6 @@ Feature: Create case
 
   Background:
     Given I am logged into "CS" as user "DECS_USER"
-    When I navigate to the "CREATE SINGLE CASE" page
 
   @Workflow @CSRegression
   Scenario Outline: As a CS user, I want to be able to create a case, so I can start the casework process for the received correspondence
@@ -12,19 +11,20 @@ Feature: Create case
     And the summary should display the owning team as "<team>"
     And the document added at case creation should be listed under the "<documentType>" document type heading
     Examples:
-      | caseType | stage                | documentType            | team                           |
+      | caseType | stage                       | documentType | team                           |
       | MIN      | Data Input           | ORIGINAL                | Performance and Process Team   |
       | DTEN     | Data Input           | ORIGINAL                | Transfers & No10 Team          |
       | TRO      | Data Input           | ORIGINAL                | Performance and Process Team   |
       | MPAM     | Creation             | Original correspondence | MPAM Creation                  |
       | MTS      | Data Input           | Original correspondence | MTS Team                       |
       | COMP     | Registration         | To document             | Complaint Registration         |
-      | COMP2    | Stage 2 Registration | To document             | Stage 2 Complaint Registration |
+      | COMP2    | Stage 2 Registration        | To document  | Stage 2 Complaint Registration |
       | IEDET    | Registration         | To document             | IE Detention                   |
       | SMC      | Registration         | To document             | Serious Misconduct             |
       | FOI      | Case Creation        | Request                 | FOI Creation                   |
       | TO       | Data Input           | Initial Correspondence  | Treat Official Creation        |
       | BF       | Case Registration    | To document             | Border Force                   |
+      | BF2      | Case Registration (Stage 2) | To document  | Border Force (Stage 2)         |
 
   @Allocation
   Scenario: A single case is allocated to the current user
@@ -47,16 +47,19 @@ Feature: Create case
 
   @Navigation
   Scenario: User should be taken back to the dashboard when they click the cancel link on the first 'Create Single Case' page
+    When I navigate to the "CREATE SINGLE CASE" page
     And I click the "Cancel" link
     Then I should be taken to the homepage
 
   @Validation
   Scenario: When creating a Single Case case type selection is required
+    When I navigate to the "CREATE SINGLE CASE" page
     And I click the "Next" button
     Then an error message should be displayed as I have not selected the case type
 
   @Validation
   Scenario: When creating a single case the date received is required
+    When I navigate to the "CREATE SINGLE CASE" page
     And I select a case type and continue
     And I enter a blank date
     And I click the "Create case" button
@@ -64,6 +67,7 @@ Feature: Create case
 
   @Validation
   Scenario: When creating a Single MIN case a valid date must be entered
+    When I navigate to the "CREATE SINGLE CASE" page
     And I select a case type and continue
     And I enter an invalid date
     And I click the "Create case" button


### PR DESCRIPTION
Added MUI page for methods that require multiple other MUI page dependencies, and created end-to-end MUI method for withdrawing a case
Added a method to CreateCase for creating a CS case and then withdrawing it in MUI, then returning to CS
Added BF2 if statement to CreateCaseStepDefs.createCase
Added BF2 to the main create case scenario
Amended COMPProgressCase and BFProgressCase so that we use a newly withdrawn case to create a stage 2 case, rather than taking a case all the way through the workflow
Added a BasePage method for checking if a checkbox identified by its label is currently visible
Added a wait for the correct page title to be visible to the clicking of the menu bar search link
Added navigateToCS method to LoginPage, for better readability of LoginPage.open() in other files