### PR TITLE
HOCS-3736 Directorates/Groups to be simplified for Allocation and Acceptance stage

### DIFF
--- a/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
@@ -157,6 +157,16 @@ public class SummaryTabStepDefs extends BasePage {
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(teamName, "Team");
     }
 
+    @And("the summary should display the owning team as the selected FOI Group")
+    public void theSummaryShouldDisplayTheOwningTeamAsTheSelectedFOIGroup() {
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("foiGroup"), "Team");
+    }
+
+    @And("the case should still be owned by the selected FOI Group")
+    public void theCaseShouldStillBeOwnedByTheSelectedFOIGroup() {
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("foiGroup"), "Team");
+    }
+
     @And("the summary should contain the Business Area, Channel Received, Home Secretary Interest selection, and Primary Correspondents details")
     public void theSummaryShouldContainTheBusinessAreaChannelReceivedAddresseeAndPrimaryCorrespondent() {
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("businessArea"), "Business Area");
@@ -251,5 +261,17 @@ public class SummaryTabStepDefs extends BasePage {
     @And("the summary should contain the old case reference")
     public void theSummaryShouldContainTheOldCaseReference() {
         summaryTab.assertPreviousCaseReferenceIsVisible(getCurrentCaseReference());
+    }
+
+    @Then("the Requested Question should be displayed in the summary tab")
+    public void theRequestedQuestionShouldBeDisplayedInTheSummaryTab() {
+        waitABit(500);
+        summaryTab.selectSummaryTab();
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("requestQuestion"), "Request Question");
+    }
+
+    @And("the summary should contain the Responsible Team")
+    public void theSummaryShouldContainTheResponsibleTeam() {
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("responsibleTeam"), "Responsible Team");
     }
 }

--- a/src/test/java/com/hocs/test/glue/decs/TimelineStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/TimelineStepDefs.java
@@ -170,12 +170,6 @@ public class TimelineStepDefs extends BasePage {
         timelineTab.assertCaseLogWithTitleContainsText("Case Extension", extensionReason);
     }
 
-    @And("an Allocation note should be visible in the timeline showing the details of the allocation")
-    public void aAllocationNoteShouldBeVisibleInTheTimelineShowingTheDetailsOfTheAllocation() {
-        String allocatedTeam = sessionVariableCalled("acceptanceTeam");
-        timelineTab.assertCaseNoteWithTitleContainsText("Allocation note", allocatedTeam);
-    }
-
     @And("an Appeal Created log should be visible in the timeline for the selected appeal type")
     public void anAppealCreatedLogShouldBeVisibleInTheTimelineForTheSelectedAppealType() {
         String appealType = sessionVariableCalled("appealType");

--- a/src/test/java/com/hocs/test/glue/foi/AcceptanceStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/foi/AcceptanceStepDefs.java
@@ -16,34 +16,26 @@ public class AcceptanceStepDefs extends BasePage {
 
     SummaryTab summaryTab;
 
-    @And("I select that the case {string} belong to this Directorate")
-    public void iSelectThatTheCaseBelongToTheDirectorate(String input) {
+    @And("I select that the case {string} belong in this Group")
+    public void iSelectThatTheCaseBelongToTheGroup(String input) {
         if (input.equalsIgnoreCase("DOES")) {
-            acceptance.selectIfCaseIsInCorrectDirectorate("Yes");
+            acceptance.selectIfCaseIsInCorrectGroup("Yes");
+            clickTheButton("Continue");
         } else if (input.equalsIgnoreCase("DOESN'T")) {
-            acceptance.selectIfCaseIsInCorrectDirectorate("No");
+            acceptance.selectIfCaseIsInCorrectGroup("No");
         } else {
             pendingStep(input + " is not defined within " + getMethodName());
         }
     }
 
-    @And("I enter a rejection reason at the Acceptance stage")
+    @And("I submit a rejection reason at the Acceptance stage")
     public void iEnterARejectionReasonAtTheAcceptanceStage() {
         acceptance.enterRejectionReason();
+        clickTheButton("Continue");
     }
 
-    @And("I select the drafting team required to respond to the request")
-    public void iSelectTheDraftingTeamRequiredToRespondToTheRequest() {
-        acceptance.selectDraftTeam();
-    }
-
-    @Then("the case should be assigned to the Drafting team selected at Acceptance")
-    public void theCaseShouldBeAssignedToTheDraftingTeamSelectedAtAcceptance() {
-        summaryTab.assertAllocatedTeam(sessionVariableCalled("selectedDraftTeam"));
-    }
-
-    @And("I {string} the Acceptance stage")
-    public void iTheAcceptanceStage(String buttonLabel) {
-        clickTheButton(buttonLabel);
+    @And("I select a Responsible Team and complete acceptance")
+    public void iSelectAResponsibleTeamAndCompleteAcceptance() {
+        acceptance.selectAResponsibleTeam();
     }
 }

--- a/src/test/java/com/hocs/test/glue/foi/AllocationStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/foi/AllocationStepDefs.java
@@ -7,37 +7,24 @@ import com.hocs.test.pages.decs.SummaryTab;
 import com.hocs.test.pages.foi.Allocation;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class AllocationStepDefs extends BasePage {
 
     Allocation allocation;
-    SummaryTab summaryTab;
 
-    @And("I select {string} as the Directorate")
-    public void iSelectAsTheDirectorate(String directorate) {
-        allocation.selectASpecificDirectorate(directorate);
-    }
-
-    @And("I select {string} as the Acceptance Team")
-    public void iSelectAsTheAcceptanceTeam(String team) {
-        allocation.selectASpecificAcceptanceTeam(team);
-        setSessionVariable("acceptanceTeam").to(team);
-    }
-
-    @Then("the Requested Question should be displayed in the summary tab")
-    public void theRequestedQuestionShouldBeDisplayedInTheSummaryTab() {
-        waitABit(500);
-        summaryTab.selectSummaryTab();
-        allocation.assertRequestQuestionIsCorrect();
-    }
-
-    @Then("the Allocation text is displayed")
-    public void allocationTextIsDisplayed() {
-        allocation.assertAllocationText();
+    @When("I select a Group")
+    public void iSelectAGroup() {
+        allocation.selectAGroup();
     }
 
     @And("I select an Account Manager")
     public void iSelectAnAccountManager() {
         allocation.selectAnAccountManager();
+    }
+
+    @Then("the Allocation text is displayed")
+    public void allocationTextIsDisplayed() {
+        allocation.assertAllocationText();
     }
 }

--- a/src/test/java/com/hocs/test/pages/decs/CreateCase.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase.java
@@ -308,7 +308,7 @@ public class CreateCase extends BasePage {
     }
 
     public void createComplaintsCaseOfRandomType() {
-        createCSCaseOfTypeWithoutDocument(getRandomComplaintsCaseType());
+        createCSCaseOfType(getRandomComplaintsCaseType());
     }
 
     public void createMPAMOrMTSCaseOfRandomType() {

--- a/src/test/java/com/hocs/test/pages/foi/Acceptance.java
+++ b/src/test/java/com/hocs/test/pages/foi/Acceptance.java
@@ -9,21 +9,21 @@ public class Acceptance extends BasePage {
 
     RecordCaseData recordCaseData;
 
-    public void selectIfCaseIsInCorrectDirectorate(String input) {
+    public void selectIfCaseIsInCorrectGroup(String input) {
         if (input.equalsIgnoreCase("YES")) {
-            recordCaseData.selectSpecificRadioButtonFromGroupWithHeading("Yes", "Does this case belong to your Directorate?");
+            recordCaseData.selectSpecificRadioButtonFromGroupWithHeading("Yes", "Does this case belong in your group?");
         } else if (input.equalsIgnoreCase("NO")) {
-            recordCaseData.selectSpecificRadioButtonFromGroupWithHeading("No", "Does this case belong to your Directorate?");
+            recordCaseData.selectSpecificRadioButtonFromGroupWithHeading("No", "Does this case belong in your group?");
         }
-    }
-
-    public void selectDraftTeam() {
-        String draftTeam = recordCaseData.selectRandomOptionFromDropdownWithHeading("Please select the team required for drafting the response");
-        setSessionVariable("selectedDraftTeam").to(draftTeam);
     }
 
     public void enterRejectionReason() {
         recordCaseData.enterSpecificTextIntoTextAreaWithHeading("Test Rejection Reason", "Reason");
         setSessionVariable("rejectionReason").to("Test Rejection Reason");
+    }
+
+    public void selectAResponsibleTeam() {
+        setSessionVariable("responsibleTeam").to(recordCaseData.selectRandomOptionFromDropdownWithHeading("Responsible Team"));
+        clickTheButton("Complete Acceptance");
     }
 }

--- a/src/test/java/com/hocs/test/pages/foi/Allocation.java
+++ b/src/test/java/com/hocs/test/pages/foi/Allocation.java
@@ -9,47 +9,29 @@ import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.decs.RecordCaseData;
 import net.serenitybdd.core.annotations.findby.FindBy;
 import net.serenitybdd.core.pages.WebElementFacade;
+import org.junit.Assert;
 
 public class Allocation extends BasePage {
 
     RecordCaseData recordCaseData;
 
-    @FindBy(xpath = "//th[text()='Request Question']/following-sibling::td")
-    public WebElementFacade requestQuestion;
-
     @FindBy(xpath = "//h2[@class='govuk-heading-m']")
     public WebElementFacade allocationText;
 
-    public void selectASpecificDirectorate(String directorate) {
-        recordCaseData.selectSpecificOptionFromDropdownWithHeading(directorate,"Directorate");
-    }
-
-    public void selectADirectorate() {
-        recordCaseData.selectRandomOptionFromDropdownWithHeading("Directorate");
-    }
-
-    public void selectASpecificAcceptanceTeam(String team) {
-        recordCaseData.selectSpecificOptionFromDropdownWithHeading(team,"Acceptance Team");
-        setSessionVariable("acceptanceTeam").to(team);
-    }
-
-    public void selectAnAcceptanceTeam() {
-        recordCaseData.selectRandomOptionFromDropdownWithHeading("Acceptance Team");
+    public void selectAGroup() {
+        String selectedGroup = recordCaseData.selectRandomOptionFromDropdownWithHeading("Group");
+        setSessionVariable("foiGroup").to(selectedGroup);
     }
 
     public void selectAnAccountManager() { recordCaseData.selectRandomOptionFromDropdownWithHeading("Account Manager"); }
 
-    public void assertRequestQuestionIsCorrect() {
-        String displayedRequestQuestion = requestQuestion.getText();
-        String enteredRequestQuestion = sessionVariableCalled("requestQuestion");
-        assertThat(displayedRequestQuestion.equals(enteredRequestQuestion), is(true));
-    }
-
     public void assertAllocationText() {
         waitForPageWithTitle("FOI Allocation");
         String displayedAllocationText = allocationText.getText();
-        String acceptanceTeam = sessionVariableCalled("acceptanceTeam");
-        String expectedAllocationText = "Case " + getCurrentCaseReference() +" will be allocated to "+ acceptanceTeam;
-        assertThat(displayedAllocationText.equals(expectedAllocationText), is(true));
+        String foiGroup = sessionVariableCalled("foiGroup");
+        String expectedAllocationText = "Case " + getCurrentCaseReference() +" will be allocated to "+ foiGroup;
+        if (!displayedAllocationText.equals(expectedAllocationText)) {
+            Assert.fail("Expected allocation text: " + expectedAllocationText +"\nDisplayed allocation text: " + displayedAllocationText);
+        }
     }
 }

--- a/src/test/java/com/hocs/test/pages/foi/FOIProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/foi/FOIProgressCase.java
@@ -115,18 +115,17 @@ public class FOIProgressCase extends BasePage {
     }
 
     public void moveCaseFromAllocationToAcceptance() {
-        allocation.selectADirectorate();
-        allocation.selectAnAcceptanceTeam();
+        allocation.selectAGroup();
         allocation.selectAnAccountManager();
         clickTheButton("Allocate Case");
-        waitABit(250);
+        waitForPageWithTitle("FOI Allocation");
         clickTheButton("Confirm Allocation");
     }
 
     public void moveCaseFromAcceptanceToConsiderAndDraft() {
-        acceptance.selectIfCaseIsInCorrectDirectorate("Yes");
+        acceptance.selectIfCaseIsInCorrectGroup("Yes");
         clickTheButton("Continue");
-        acceptance.selectDraftTeam();
+        acceptance.selectAResponsibleTeam();
         clickTheButton("Complete Acceptance");
     }
 

--- a/src/test/resources/features/foi/Acceptance.feature
+++ b/src/test/resources/features/foi/Acceptance.feature
@@ -8,20 +8,19 @@ Feature: Acceptance
 
   #HOCS-2586, HOCS-2723
   Scenario: User is able to complete the Acceptance stage
-    And I select that the case "Does" belong to this Directorate
-    And I "Continue" the Acceptance stage
-    And I select the drafting team required to respond to the request
-    And I click the "Complete Acceptance" button
+    And I select that the case "Does" belong in this Group
+    And I select a Responsible Team and complete acceptance
     Then the case should be moved to the "Consider and Draft" stage
-    And the case should be assigned to the Drafting team selected at Acceptance
+    And the case should still be owned by the selected FOI Group
+    And the summary should contain the Responsible Team
     And the read-only Case Details accordion should contain all case information entered during the "Acceptance" stage
 
+  # Expected failure. Defect HOCS-4876 raised.
   #HOCS-2753, HOCS-2741
   @FOIRegression
   Scenario: User rejects a case at the Acceptance stage
-    And I select that the case "Doesn't" belong to this Directorate
-    And I enter a rejection reason at the Acceptance stage
-    And I "Continue" the Acceptance stage
+    And I select that the case "Doesn't" belong in this Group
+    And I submit a rejection reason at the Acceptance stage
     Then the case should be returned to the "Allocation" stage
     And a Rejection note should be visible in the timeline showing the submitted reason for the return of the case
     And the rejected column of the case in the "FOI Allocation" workstack should display rejected by "Acceptance"

--- a/src/test/resources/features/foi/Allocation.feature
+++ b/src/test/resources/features/foi/Allocation.feature
@@ -5,20 +5,14 @@ Feature: Allocation
     Given I am logged into "CS" as user "FOI_USER"
     When I create a "FOI" case and move it to the "Allocation" stage
 
-  #HOCS-3268
-  @FOIRegression
-  Scenario: User is able to see the Requested Question entered at creation
-    Then the Requested Question should be displayed in the summary tab
-
   #HOCS-3626 #HOCS-2326
   @FOIRegression
   Scenario: User is able to complete the Allocation stage
-    And I select "HMPO" as the Directorate
-    And I select "FOI HMPO Intelligence Acceptance Team" as the Acceptance Team
+    When I select a Group
     And I select an Account Manager
     And I click the "Allocate Case" button
     And the Allocation text is displayed
     And I click the "Confirm Allocation" button
     Then the case should be moved to the "Acceptance" stage
+    And the summary should display the owning team as the selected FOI Group
     And the read-only Case Details accordion should contain all case information entered during the "Allocation" stage
-    And an Allocation note should be visible in the timeline showing the details of the allocation

--- a/src/test/resources/features/foi/CaseCreationStage.feature
+++ b/src/test/resources/features/foi/CaseCreationStage.feature
@@ -14,6 +14,8 @@ Feature: Case Creation Stage
     And I submit a valid request acknowledgement response date
     Then the case should be moved to the "Allocation" stage
     And the read-only Case Details accordion should contain all case information entered during the "Case Creation" stage
+    And the Requested Question should be displayed in the summary tab
+
 
   #HOCS-3482 HOCS-3838
   @FOIRegression


### PR DESCRIPTION
Updated FOI Allocation and Acceptance scenarios/methods to match workflow changes in HOCS-3736.

Fixed complaints case documents scenarios that were failing due to attempting to create a stage 2 case without a document.