### PR TITLE
Noticed that we had the wrong logic for the (currently failing due to…

### DIFF
--- a/src/test/java/com/hocs/test/glue/complaints/DataInputStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/DataInputStepDefs.java
@@ -53,6 +53,14 @@ public class DataInputStepDefs extends BasePage {
         safeClickOn(continueButton);
     }
 
+    @And("I record that the case was received by post")
+    public void iRecordThatTheCaseWasReceivedByPost() {
+        dataInput.selectCategory();
+        dataInput.enterDescriptionOfComplaint();
+        dataInput.selectASpecificComplaintChannel("Post");
+        safeClickOn(continueButton);
+    }
+
     @And("I complete the Data Input stage with {string} as the business area")
     public void iCompleteTheDataInputStageWithAsTheBusinessArea(String businessArea) {
         dataInput.selectSpecificBusinessArea(businessArea);

--- a/src/test/resources/features/cs/Deadlines.feature
+++ b/src/test/resources/features/cs/Deadlines.feature
@@ -90,5 +90,5 @@ Feature: Deadlines
     When I select "GRO" as the business area for the POGR case
     And I add a "Complainant" correspondent
     And I confirm the primary correspondent
-    And I record that the case was not received by post
+    And I record that the case was received by post
     Then the case deadline date displayed in the summary is correct for a "non-Priority, Post GRO complaint" case


### PR DESCRIPTION
… a defect) deadline scenario for non-post gro complaints.