### PR TITLE
Test fixes for failing COMP2 scenarios

### DIFF
--- a/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
@@ -115,7 +115,7 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
     }
 
     @And("I record that the case is a Priority case")
-    public void  iRecordThatTheCaseIsAPriorityCase() {
+    public void iRecordThatTheCaseIsAPriorityCase() {
         complaintsRegistrationAndDataInput.selectPOGRCategory();
         complaintsRegistrationAndDataInput.enterADescriptionOfTheComplaint();
         complaintsRegistrationAndDataInput.selectIsLoARequired();

--- a/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
@@ -115,7 +115,7 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
     }
 
     @And("I record that the case is a Priority case")
-    public void iRecordThatTheCaseIsAPriorityCase() {
+    public void  iRecordThatTheCaseIsAPriorityCase() {
         complaintsRegistrationAndDataInput.selectPOGRCategory();
         complaintsRegistrationAndDataInput.enterADescriptionOfTheComplaint();
         complaintsRegistrationAndDataInput.selectIsLoARequired();

--- a/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
@@ -118,16 +118,20 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
     public void iRecordThatTheCaseIsAPriorityCase() {
         complaintsRegistrationAndDataInput.selectPOGRCategory();
         complaintsRegistrationAndDataInput.enterADescriptionOfTheComplaint();
+        complaintsRegistrationAndDataInput.selectIsLoARequired();
         complaintsRegistrationAndDataInput.checkPriorityCheckbox();
         safeClickOn(continueButton);
+        waitABit(1000);
     }
 
     @And("I record that the case was not received by post")
     public void iRecordThatTheCaseWasNotReceivedByPost() {
         complaintsRegistrationAndDataInput.selectPOGRCategory();
         complaintsRegistrationAndDataInput.enterADescriptionOfTheComplaint();
+        complaintsRegistrationAndDataInput.selectIsLoARequired();
         complaintsRegistrationAndDataInput.selectASpecificComplaintChannel("Email");
         safeClickOn(continueButton);
+        waitABit(1000);
     }
 
     @And("I record that the case was received by post")
@@ -135,6 +139,8 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
         complaintsRegistrationAndDataInput.selectPOGRCategory();
         complaintsRegistrationAndDataInput.enterADescriptionOfTheComplaint();
         complaintsRegistrationAndDataInput.selectASpecificComplaintChannel("Post");
+        complaintsRegistrationAndDataInput.selectIsLoARequired();
         safeClickOn(continueButton);
+        waitABit(1000);
     }
 }

--- a/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
@@ -287,7 +287,7 @@ public class SummaryTabStepDefs extends BasePage {
     @And("the summary should contain details of the phone call")
     public void theSummaryShouldContainDetailsOfThePhoneCall() {
         String resolvedByPhone = sessionVariableCalled("resolvedByPhone");
-        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(resolvedByPhone, "Resolved by Phone");
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(resolvedByPhone, "Was the case resolved by phone call?");
         if (resolvedByPhone.equalsIgnoreCase("Yes")) {
             summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("callDate"), "Date of Call");
         }

--- a/src/test/java/com/hocs/test/pages/complaints/ComplaintsDraft.java
+++ b/src/test/java/com/hocs/test/pages/complaints/ComplaintsDraft.java
@@ -64,7 +64,7 @@ public class ComplaintsDraft extends BasePage {
     }
 
     public void selectIfResolvedByPhoneCall(String yesNo) {
-        recordCaseData.selectSpecificRadioButtonFromGroupWithHeading(yesNo, "Resolved by Phone");
+        recordCaseData.selectSpecificRadioButtonFromGroupWithHeading(yesNo, "Was the case resolved by phone call?");
         setSessionVariable("resolvedByPhone").to(yesNo);
     }
 
@@ -75,7 +75,7 @@ public class ComplaintsDraft extends BasePage {
     }
 
     public void enterDetailsOfPhoneCall() {
-        String callDetails = recordCaseData.enterTextIntoTextAreaWithHeading("Case Notes");
+        String callDetails = recordCaseData.enterTextIntoTextAreaWithHeading("Details of Phone Call");
         setSessionVariable("callDetails").to(callDetails);
     }
 }

--- a/src/test/resources/features/complaints/ComplaintsDraft.feature
+++ b/src/test/resources/features/complaints/ComplaintsDraft.feature
@@ -298,7 +298,7 @@ Feature: Complaints Draft
     And the read-only Case Details accordion should contain all case information entered during the "Draft" stage
     Examples:
       | businessArea |
-#      | HMPO         |
+      | HMPO         |
       | GRO          |
 
   @ComplaintsWorkflow @ComplaintsRegression2 @POGRComplaints

--- a/src/test/resources/features/complaints/ComplaintsDraft.feature
+++ b/src/test/resources/features/complaints/ComplaintsDraft.feature
@@ -249,17 +249,6 @@ Feature: Complaints Draft
 #     BF STAGE 2 COMPLAINTS
 
   @ComplaintsWorkflow @ComplaintsRegression2 @BFComplaints
-  Scenario: User completes the Draft stage for a BF complaint case
-    Given I am logged into "CS" as user "BF_USER"
-    When I get a "BF2" case at the "Draft" stage
-    And I upload my Primary "DRAFT" document
-    And I select the "Response is ready to send" action at the Draft stage
-    Then the case should be moved to the "Send draft response (Stage 2)" stage
-    And the summary should display the owning team as "Border Force (Stage 2)"
-    And the read-only Case Details accordion should contain all case information entered during the "Draft (Stage 2)" stage
-    And the selected document should be tagged as the primary draft
-
-  @ComplaintsWorkflow @ComplaintsRegression2 @BFComplaints
   Scenario: User can send a BF stage 2 complaint case to the QA stage from Draft
     Given I am logged into "CS" as user "BF_USER"
     When I get a "BF2" case at the "Draft" stage

--- a/src/test/resources/features/complaints/ComplaintsDraft.feature
+++ b/src/test/resources/features/complaints/ComplaintsDraft.feature
@@ -298,7 +298,7 @@ Feature: Complaints Draft
     And the read-only Case Details accordion should contain all case information entered during the "Draft" stage
     Examples:
       | businessArea |
-      | HMPO         |
+#      | HMPO         |
       | GRO          |
 
   @ComplaintsWorkflow @ComplaintsRegression2 @POGRComplaints
@@ -307,8 +307,10 @@ Feature: Complaints Draft
     When I get a POGR case with "<businessArea>" as the Business Area at the "Draft" stage
     And I select the "Respond by Phone" action at the Draft stage
     And I select that the case was not resolved by the phone call
+    And I submit details of the phone call
     And I click the "Continue" button
     Then I should be returned to the "Draft" page
+    And a Phone Call Summary note should be visible in the timeline containing the details of the Phone Call
     And the summary should contain details of the phone call
     Examples:
       | businessArea |

--- a/src/test/resources/features/complaints/ComplaintsRegistration&DataInput.feature
+++ b/src/test/resources/features/complaints/ComplaintsRegistration&DataInput.feature
@@ -207,7 +207,7 @@ Feature: Registration
     And I enter details on the Data Input screen
     And I add an "Interim Letter" type document to the case
     And I enter the date that the Interim letter was sent
-    Then the case should be moved to the "Investigating Triage" stage
+    Then the case should be moved to the "Investigation" stage
     And the summary should display the owning team as "HMPO Complaints"
     And the read-only Case Details accordion should contain all case information entered during the "Data Input" stage
 
@@ -222,6 +222,6 @@ Feature: Registration
     And I add an "Interim Letter" type document to the case
     And I enter the date that the Interim letter was sent
     And I select the investigating team for the case
-    Then the case should be moved to the "Investigating Triage" stage
+    Then the case should be moved to the "Investigation" stage
     And the POGR case should be assigned to the correct investigating team
     And the read-only Case Details accordion should contain all case information entered during the "Data Input" stage


### PR DESCRIPTION
Removed erroneous BF2 scenario that doesnt match DECS AC.
Added required LOA question method to POGR deadline methods, and small wait to let deadline change process before checking on frontend.
Updated POGR Draft phone call scenarios with new field headers, and added step and assertion to non-conclusive phone call scenario.
Updated POGR Data Input scenario assertions with correct second stage title.