### PR TITLE
HOCS-5246 Rejection note when returning to Investigation from Draft

### DIFF
--- a/src/test/java/com/hocs/test/glue/complaints/ComplaintsDraftStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/ComplaintsDraftStepDefs.java
@@ -33,7 +33,13 @@ public class ComplaintsDraftStepDefs extends BasePage {
 
     @And("I submit a rejection reason")
     public void iSubmitARejectionReason() {
-        String rejectionReason = enterTextIntoTextAreaWithHeading("Enter reason for rejection");
+        String rejectionReason;
+        if (pogrCase()) {
+            rejectionReason = enterTextIntoTextAreaWithHeading("Reason for rejection");
+        } else {
+            rejectionReason = enterTextIntoTextAreaWithHeading("Enter reason for rejection");
+
+        }
         setSessionVariable("rejectionReason").to(rejectionReason);
         clickTheButton("Reject");
     }

--- a/src/test/java/com/hocs/test/glue/decs/LoginStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/LoginStepDefs.java
@@ -8,6 +8,7 @@ import static config.User.FAKE;
 import static config.User.MPAM_USER;
 import static config.User.FOI_USER;
 import static config.User.IEDET_USER;
+import static config.User.POGR_USER;
 import static config.User.SMC_USER;
 import static config.User.TO_USER;
 import static config.User.WCS_USER;
@@ -195,7 +196,7 @@ public class LoginStepDefs extends BasePage {
 
     private boolean loggedInAsTargetUser() {
         boolean targetUserLoggedIn = false;
-        if (targetUser == DCU_USER | targetUser == MPAM_USER | targetUser == DECS_USER | targetUser == WCS_USER | targetUser == COMP_USER  | targetUser == WCS_USER | targetUser == FOI_USER | targetUser == IEDET_USER | targetUser == SMC_USER | targetUser == BF_USER | targetUser == TO_USER) {
+        if (targetUser == DCU_USER | targetUser == MPAM_USER | targetUser == DECS_USER | targetUser == WCS_USER | targetUser == COMP_USER  | targetUser == WCS_USER | targetUser == FOI_USER | targetUser == IEDET_USER | targetUser == SMC_USER | targetUser == BF_USER | targetUser == TO_USER | targetUser == POGR_USER) {
             if (dashboard.checkTargetUserIsLoggedInUsingVisibleTeams(targetUser)) {
                 targetUserLoggedIn = true;
             } else {

--- a/src/test/java/com/hocs/test/glue/decs/ProgressCaseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/ProgressCaseStepDefs.java
@@ -73,13 +73,13 @@ public class ProgressCaseStepDefs extends BasePage {
                 foiProgressCase.completeTheFOIStage(stage);
                 break;
             case "WCS":
-                wcsProgressCase.completeTheWCSStageSoThatCaseMovesToTargetStage(stage,"Happy Path");
+                wcsProgressCase.completeTheWCSStageSoThatCaseMovesToTargetStage(stage, "Happy Path");
                 break;
             case "TO":
                 toProgressCase.completeTheTOStageSoThatCaseMovesToTargetStage(stage, "Happy Path");
                 break;
             case "POGR":
-                pogrProgressCase.completeThePOGRStageSoThatCaseMovesToTargetStage(stage,"Happy Path");
+                pogrProgressCase.completeThePOGRStageSoThatCaseMovesToTargetStage(stage, "Happy Path");
                 break;
             default:
                 pendingStep(caseType + " is not defined within " + getMethodName());
@@ -110,7 +110,7 @@ public class ProgressCaseStepDefs extends BasePage {
                 break;
             case "BF":
             case "BF2":
-                bfProgressCase.moveCaseOfTypeFromCurrentStageToTargetStage(caseType,currentStage, targetStage);
+                bfProgressCase.moveCaseOfTypeFromCurrentStageToTargetStage(caseType, currentStage, targetStage);
                 break;
             case "FOI":
                 foiProgressCase.moveCaseFromCurrentStageToTargetStage(currentStage, targetStage);
@@ -145,15 +145,11 @@ public class ProgressCaseStepDefs extends BasePage {
     @And("I get a {string} case/claim at (the ){string}( stage)")
     public void iGetACaseAtAStage(String caseType, String stage) {
         iCreateACaseAndMoveItToAStage(caseType, stage);
-        boolean previousStageWasSticky;
-        previousStageWasSticky = (caseType.equals("FOI") && (stage.equalsIgnoreCase("CASE CREATION") || stage.equalsIgnoreCase(
-                "ACCEPTANCE") || stage.equalsIgnoreCase("ALLOCATION")));
-            if (stage.equalsIgnoreCase("CASE CLOSED") || previousStageWasSticky) {
-                dashboard.getCurrentCase();
-            } else {
-                dashboard.getAndClaimCurrentCase();
-            }
-
+        if (stage.equalsIgnoreCase("CASE CLOSED") || previousStageWouldHaveAutoAllocated(caseType, stage)) {
+            dashboard.getCurrentCase();
+        } else {
+            dashboard.getAndClaimCurrentCase();
+        }
     }
 
     @And("I get a DCU {string} case at the {string} stage that should be copied to Number 10")
@@ -180,9 +176,9 @@ public class ProgressCaseStepDefs extends BasePage {
 
     @When("I create a {string} case for a {string} complaint and move it to {string}( stage)")
     public void iCreateACaseForAComplaintAndMoveItToStage(String caseType, String complaintType, String stage) {
-        if(caseType.equalsIgnoreCase("BF")) {
+        if (caseType.equalsIgnoreCase("BF")) {
             bfProgressCase.createCaseOfTypeAndMoveItToTargetStageWithSpecifiedComplaintType(caseType, complaintType, stage);
-        } else{
+        } else {
             compProgressCase.createCaseOfTypeAndMoveItToTargetStageWithSpecifiedComplaintType(caseType, complaintType, stage);
         }
     }
@@ -197,6 +193,22 @@ public class ProgressCaseStepDefs extends BasePage {
     @And("I get a POGR case with {string} as the Business Area at the {string} stage")
     public void iCreateAPOGRCaseWithAsTheBusinessAreaAndMoveItToTheStage(String businessArea, String stage) {
         pogrProgressCase.createCaseAndMoveItToTargetStageWithSpecificBusinessArea(businessArea, stage);
-        dashboard.getAndClaimCurrentCase();
+        if (stage.equalsIgnoreCase("CASE CLOSED") || previousStageWouldHaveAutoAllocated("POGR", stage)) {
+            dashboard.getCurrentCase();
+        } else {
+            dashboard.getAndClaimCurrentCase();
+        }
+    }
+
+    private boolean previousStageWouldHaveAutoAllocated(String caseType, String stage) {
+        switch (caseType) {
+            case "FOI":
+                return stage.equalsIgnoreCase("CASE CREATION") || stage.equalsIgnoreCase(
+                        "ACCEPTANCE") || stage.equalsIgnoreCase("ALLOCATION");
+            case "POGR":
+                return (stage.equalsIgnoreCase("DRAFT"));
+            default:
+                return false;
+        }
     }
 }

--- a/src/test/java/com/hocs/test/pages/decs/Dashboard.java
+++ b/src/test/java/com/hocs/test/pages/decs/Dashboard.java
@@ -95,6 +95,11 @@ public class Dashboard extends BasePage {
     @FindBy(xpath = "//span[text()='Treat Official Creation']")
     public WebElementFacade treatOfficialCreationWorkstack;
 
+    //POGR Teams
+
+    @FindBy(xpath = "//span[text()='HMPO/GRO Registration']")
+    public WebElementFacade hmpoGroRegistrationWorkstack;
+
     // Basic Methods
 
     public void enterCaseReferenceIntoSearchBar(String caseReference) {
@@ -345,6 +350,11 @@ public class Dashboard extends BasePage {
                 break;
             case "TO_USER":
                 if (treatOfficialCreationWorkstack.isVisible()) {
+                    correctUser = true;
+                }
+                break;
+            case "POGR_USER":
+                if (hmpoGroRegistrationWorkstack.isVisible()) {
                     correctUser = true;
                 }
                 break;

--- a/src/test/resources/features/complaints/ComplaintsDraft.feature
+++ b/src/test/resources/features/complaints/ComplaintsDraft.feature
@@ -322,7 +322,10 @@ Feature: Complaints Draft
     Given I am logged into "CS" as user "POGR_USER"
     When I get a POGR case with "<businessArea>" as the Business Area at the "Draft" stage
     And I select the "Return to Investigation" action at the Draft stage
+    And I submit a rejection reason
     Then the case should be returned to the "Investigation" stage
+    And the case "should" be allocated to me in the summary
+    And a Rejection note should be visible in the timeline showing the submitted reason for the return of the case
     And the read-only Case Details accordion should contain all case information entered during the "Draft" stage
     Examples:
       | businessArea |


### PR DESCRIPTION
Amended POGR Draft rejection scenario to include step for Rejection note, and assertions for Rejection note and auto-allocation.
Added if statement to ComplaintsDraftStepDefs.iSubmitARejectionReason to account for slight header difference with POGR cases.
Added POGR_USER to LoginStepDefs.loggedInAsTargetUser, and added POGR team to Dashboard, for quicker check between POGR scenario examples.
Refactored some logic in ProgressCaseStepDefs.java that deals with not trying to claim cases that would have auto-allocated in the previous stage into a new method.