### PR TITLE
HOCS-4791 Ability to create a stage 2 case

### DIFF
--- a/src/test/java/com/hocs/test/glue/decs/WorkstacksStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/WorkstacksStepDefs.java
@@ -517,6 +517,15 @@ public class WorkstacksStepDefs extends BasePage {
                 }
                 dashboard.selectMyCases();
                 break;
+            case "POGR REGISTRATION (STAGE 2)":
+                try {
+                    dashboard.selectPOGR2RegistrationTeam();
+                } catch (NoSuchElementException e) {
+                    createCase.createCSCaseOfType("POGR2");
+                    dashboard.goToDashboard();
+                    dashboard.selectPOGR2RegistrationTeam();
+                }
+                break;
             default:
                 pendingStep(workstack + " is not defined within " + getMethodName());
         }

--- a/src/test/java/com/hocs/test/pages/decs/CreateCase.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase.java
@@ -266,15 +266,10 @@ public class CreateCase extends BasePage {
     // Multi Step Methods
 
     private void createCSCase(String caseType, boolean addDocument, String receivedDate) {
-        if (caseType.equalsIgnoreCase("COMP2")) {
-            this.stage1CaseType = "COMP";
+        if(caseType.contains("2")) {
+            this.stage1CaseType = caseType.substring(0, caseType.indexOf("2"));
             escalateAStage1CaseToStage2();
-        }
-        if (caseType.equals("BF2")) {
-            this.stage1CaseType = "BF";
-            escalateAStage1CaseToStage2();
-        }
-        if (!caseType.equals("COMP2") && !caseType.equalsIgnoreCase("BF2")) {
+        } else {
             dashboard.selectCreateSingleCaseLinkFromMenuBar();
             if (!nextButton.isVisible()) {
                 dashboard.selectCreateSingleCaseLinkFromMenuBar();
@@ -379,7 +374,10 @@ public class CreateCase extends BasePage {
     private boolean checkIfRandomStage1CaseEligibleForEscalationCanBeFound() {
         dashboard.selectSearchLinkFromMenuBar();
         selectStage1CaseTypeSearchCriteriaIfVisible();
-        search.enterComplaintsSearchCriteria("Complainant Home Office Reference", getCurrentMonth() + "/" + getCurrentYear());
+        if (!this.stage1CaseType.equalsIgnoreCase("POGR")) {
+            search.enterComplaintsSearchCriteria("Complainant Home Office Reference", getCurrentMonth() + "/" + getCurrentYear());
+
+        }
         search.clickTheButton("Search");
         search.waitForResultsPage();
         return search.checkVisibilityOfEscalationHypertext();
@@ -419,6 +417,9 @@ public class CreateCase extends BasePage {
         }
         else if (stage1CaseType.equalsIgnoreCase("BF") && checkboxWithLabelIsCurrentlyVisible("Border Force Case")) {
             checkSpecificCheckbox("Border Force Case");
+        }
+        if(stage1CaseType.equalsIgnoreCase("POGR")) {
+            checkSpecificCheckbox("HMPO/GRO Complaint Case");
         }
     }
 

--- a/src/test/java/com/hocs/test/pages/decs/Dashboard.java
+++ b/src/test/java/com/hocs/test/pages/decs/Dashboard.java
@@ -100,6 +100,9 @@ public class Dashboard extends BasePage {
     @FindBy(xpath = "//span[text()='HMPO/GRO Registration']")
     public WebElementFacade hmpoGroRegistrationWorkstack;
 
+    @FindBy(xpath = "//span[text()='HMPO/GRO Registration (Stage 2)']")
+    public WebElementFacade hmpoGroRegistrationStage2Workstack;
+
     // Basic Methods
 
     public void enterCaseReferenceIntoSearchBar(String caseReference) {
@@ -222,6 +225,10 @@ public class Dashboard extends BasePage {
 
     public void selectPOGRRegistrationTeam() {
         safeClickOn(hmpoGroRegistrationWorkstack);
+    }
+
+    public void selectPOGR2RegistrationTeam() {
+        safeClickOn(hmpoGroRegistrationStage2Workstack);
     }
 
     public void selectWorkstackByTeamName(String teamName) {

--- a/src/test/java/com/hocs/test/pages/decs/SummaryTab.java
+++ b/src/test/java/com/hocs/test/pages/decs/SummaryTab.java
@@ -183,6 +183,7 @@ public class SummaryTab extends BasePage {
                     break;
                 case "HOME SECRETARY SIGN-OFF":
                 case "POGR":
+                case "POGR2":
                 case "NON-PRIORITY, POST GRO COMPLAINT":
                     expectedNumberOfWorkdaysTillDeadline = 10;
                     break;

--- a/src/test/java/com/hocs/test/pages/decs/Workstacks.java
+++ b/src/test/java/com/hocs/test/pages/decs/Workstacks.java
@@ -820,6 +820,7 @@ public class Workstacks extends BasePage {
                         "Extended"));
                 break;
             case "POGR REGISTRATION":
+            case "POGR REGISTRATION (STAGE 2)":
                 requiredColumns.addAll(Arrays.asList("Select", "Correspondent/Reference", "Current Stage", "Owner", "Deadline",
                         "Urgency", "Days", "Rejected"));
                 break;

--- a/src/test/resources/features/complaints/ComplaintsWorkstacks.feature
+++ b/src/test/resources/features/complaints/ComplaintsWorkstacks.feature
@@ -113,7 +113,7 @@ Feature: Complaints Workstacks
 
 #     POGR COMPLAINTS
 
-  @ComplaintsRegression2 @IEDETComplaints
+  @ComplaintsRegression2 @POGRComplaints
   Scenario Outline: HMPO/GRO complaints user sees the required information when viewing a workstack
     Given I am logged into "CS" as user "POGR_USER"
     And I enter the "<workstack>" workstack
@@ -122,6 +122,17 @@ Feature: Complaints Workstacks
       | workstack         |
       | POGR Registration |
       | POGR My Cases     |
+
+
+#     POGR STAGE 2 COMPLAINTS
+
+#  SCENARIO AWAITING CONFIGURATION OF POGR2 WORKSTACKS
+
+#  @ComplaintsRegression2 @POGRComplaints
+#  Scenario: HMPO/GRO complaints user sees the required information when viewing a Stage 2 workstack
+#    Given I am logged into "CS" as user "POGR_USER"
+#    And I enter the "POGR Registration (Stage 2)" workstack
+#    Then the "POGR Registration (Stage 2)" workstack should contain only the expected columns
 
 
 #     ALL COMPLAINTS
@@ -155,4 +166,7 @@ Feature: Complaints Workstacks
       | IEDET    | IEDET_USER | 21           | IE Detention                   |
       | BF       | BF_USER    | 21           | Border Force                   |
       | BF2      | BF_USER    | 21           | Border Force (Stage 2)         |
-      | POGR     | POGR_USER  | 21           | HMPO/GRO Registration          |
+      | POGR     | POGR_USER  | 11           | HMPO/GRO Registration          |
+#      | POGR2    | POGR_USER  | 11           | HMPO/GRO Registration (Stage 2)|
+
+  #    POGR2 Example awaiting configuration of POGR2 workstacks

--- a/src/test/resources/features/cs/CreateCase.feature
+++ b/src/test/resources/features/cs/CreateCase.feature
@@ -11,21 +11,22 @@ Feature: Create case
     And the summary should display the owning team as "<team>"
     And the document added at case creation should be listed under the "<documentType>" document type heading
     Examples:
-      | caseType | stage                       | documentType            | team                           |
-      | MIN      | Data Input                  | ORIGINAL                | Performance and Process Team   |
-      | DTEN     | Data Input                  | ORIGINAL                | Transfers & No10 Team          |
-      | TRO      | Data Input                  | ORIGINAL                | Performance and Process Team   |
-      | MPAM     | Creation                    | Original correspondence | MPAM Creation                  |
-      | MTS      | Data Input                  | Original correspondence | MTS Team                       |
-      | COMP     | Registration                | To document             | Complaint Registration         |
-      | COMP2    | Stage 2 Registration        | To document             | Stage 2 Complaint Registration |
-      | IEDET    | Registration                | To document             | IE Detention                   |
-      | SMC      | Registration                | To document             | SMC Registration               |
-      | FOI      | Case Creation               | Request                 | FOI Creation                   |
-      | TO       | Data Input                  | Initial Correspondence  | Treat Official Creation        |
-      | BF       | Case Registration           | To document             | Border Force                   |
-      | BF2      | Case Registration (Stage 2) | To document             | Border Force (Stage 2)         |
-      | POGR     | Data Input                  | Original Complaint      | HMPO/GRO Registration          |
+      | caseType | stage                       | documentType            | team                            |
+      | MIN      | Data Input                  | ORIGINAL                | Performance and Process Team    |
+      | DTEN     | Data Input                  | ORIGINAL                | Transfers & No10 Team           |
+      | TRO      | Data Input                  | ORIGINAL                | Performance and Process Team    |
+      | MPAM     | Creation                    | Original correspondence | MPAM Creation                   |
+      | MTS      | Data Input                  | Original correspondence | MTS Team                        |
+      | COMP     | Registration                | To document             | Complaint Registration          |
+      | COMP2    | Stage 2 Registration        | To document             | Stage 2 Complaint Registration  |
+      | IEDET    | Registration                | To document             | IE Detention                    |
+      | SMC      | Registration                | To document             | SMC Registration                |
+      | FOI      | Case Creation               | Request                 | FOI Creation                    |
+      | TO       | Data Input                  | Initial Correspondence  | Treat Official Creation         |
+      | BF       | Case Registration           | To document             | Border Force                    |
+      | BF2      | Case Registration (Stage 2) | To document             | Border Force (Stage 2)          |
+      | POGR     | Data Input                  | Original Complaint      | HMPO/GRO Registration           |
+      | POGR2    | Data Input                  | To document             | HMPO/GRO Registration (Stage 2) |
 
 
   @Allocation

--- a/src/test/resources/features/cs/Deadlines.feature
+++ b/src/test/resources/features/cs/Deadlines.feature
@@ -39,6 +39,7 @@ Feature: Deadlines
       | BF       |
       | BF2      |
       | POGR     |
+      | POGR2    |
 
   @DCURegression
   Scenario: As a DCU User, when I select that the Home Secretary is the Private Office team, I expect the cases deadlines to reflect a 10 day SLA


### PR DESCRIPTION
Added in logic for creating a POGR2 case.
Added scenario examples for creating a POGR2 case and checking a POGR2 case deadline.
Added workstack scenario examples for checking a stage 2 workstack configuration and overdue deadline highlighting, but have commented these out until POGR2 workstacks are configured. Should be added in a later date.