### PR TITLE
HOCS-4805 POGR2 GRO Deadlines

### DIFF
--- a/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
@@ -114,38 +114,26 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
         safeClickOn(finishButton);
     }
 
-    @And("I record that the case is a Priority case")
-    public void iRecordThatTheCaseIsAPriorityCase() {
+    @And("I record that the GRO case is a {string}")
+    public void iRecordThatTheCaseIsA(String deadlineDefiningFactor) {
         complaintsRegistrationAndDataInput.enterDateOfCorrespondence();
         complaintsRegistrationAndDataInput.selectComplaintCategory();
         complaintsRegistrationAndDataInput.selectComplaintReason();
         complaintsRegistrationAndDataInput.enterADescriptionOfTheComplaint();
         complaintsRegistrationAndDataInput.selectIsLoARequired();
-        complaintsRegistrationAndDataInput.checkPriorityCheckbox();
-        safeClickOn(continueButton);
-        waitABit(1000);
-    }
-
-    @And("I record that the case was not received by post")
-    public void iRecordThatTheCaseWasNotReceivedByPost() {
-        complaintsRegistrationAndDataInput.enterDateOfCorrespondence();
-        complaintsRegistrationAndDataInput.selectComplaintCategory();
-        complaintsRegistrationAndDataInput.selectComplaintReason();
-        complaintsRegistrationAndDataInput.enterADescriptionOfTheComplaint();
-        complaintsRegistrationAndDataInput.selectIsLoARequired();
-        complaintsRegistrationAndDataInput.selectASpecificComplaintChannel("Email");
-        safeClickOn(continueButton);
-        waitABit(1000);
-    }
-
-    @And("I record that the case was received by post")
-    public void iRecordThatTheCaseWasReceivedByPost() {
-        complaintsRegistrationAndDataInput.enterDateOfCorrespondence();
-        complaintsRegistrationAndDataInput.selectComplaintCategory();
-        complaintsRegistrationAndDataInput.selectComplaintReason();
-        complaintsRegistrationAndDataInput.enterADescriptionOfTheComplaint();
-        complaintsRegistrationAndDataInput.selectASpecificComplaintChannel("Post");
-        complaintsRegistrationAndDataInput.selectIsLoARequired();
+        switch (deadlineDefiningFactor) {
+            case "Priority GRO complaint":
+                complaintsRegistrationAndDataInput.checkPriorityCheckbox();
+                break;
+            case "non-Priority, non-Post GRO complaint":
+                complaintsRegistrationAndDataInput.selectASpecificComplaintChannel("Email");
+                break;
+            case "non-Priority, Post GRO complaint":
+                complaintsRegistrationAndDataInput.selectASpecificComplaintChannel("Post");
+                break;
+            default:
+                pendingStep(deadlineDefiningFactor + " is not defined within " + getMethodName());
+        }
         safeClickOn(continueButton);
         waitABit(1000);
     }

--- a/src/test/java/com/hocs/test/glue/decs/CreateCaseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/CreateCaseStepDefs.java
@@ -378,4 +378,10 @@ public class CreateCaseStepDefs extends BasePage {
         pogrProgressCase.createCaseAndMoveItToTargetStageWithSetBusinessAreaAndPriority(businessArea, false, "Investigation");
         dashboard.waitForDashboard();
     }
+
+    @And("I escalate the closed case to Stage 2")
+    public void iEscalateTheClosedCaseToStage() {
+        createCase.createAStage2CaseFromASpecificClosedStage1Case(getCurrentCaseReference());
+        confirmationScreens.goToCaseFromConfirmationScreen();
+    }
 }

--- a/src/test/java/com/hocs/test/glue/decs/ManagementUIStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/ManagementUIStepDefs.java
@@ -7,6 +7,7 @@ import static net.serenitybdd.core.Serenity.setSessionVariable;
 
 import com.hocs.test.pages.dcu.DCUProgressCase;
 import com.hocs.test.pages.decs.CreateCase;
+import com.hocs.test.pages.managementUI.MUI;
 import com.hocs.test.pages.managementUI.TemplateManagement;
 import com.hocs.test.pages.managementUI.WithdrawACase;
 import com.hocs.test.pages.decs.BasePage;
@@ -36,6 +37,8 @@ public class ManagementUIStepDefs extends BasePage {
     DCUProgressCase dcuProgressCase;
 
     Markup markup;
+
+    MUI mui;
 
     MUIDashboard muiDashboard;
 
@@ -1169,6 +1172,12 @@ public class ManagementUIStepDefs extends BasePage {
     @Then("the success message for amending a Business Area should be displayed")
     public void theSuccessMessageForAmendingABusinessAreaShouldBeDisplayed() {
         listsManagement.assertSuccessMessageForAmendingBusinessAreaVisible();
+    }
+
+    @And("I withdraw the case")
+    public void iWithdrawTheCase() {
+        mui.withdrawACaseInMUI(getCurrentCaseReference());
+        loginPage.navigateToCS();
     }
 }
 

--- a/src/test/java/com/hocs/test/pages/complaints/ComplaintsTriageAndInvestigation.java
+++ b/src/test/java/com/hocs/test/pages/complaints/ComplaintsTriageAndInvestigation.java
@@ -231,7 +231,7 @@ public class ComplaintsTriageAndInvestigation extends BasePage {
     }
 
     public void enterLoAReceivedDetails() {
-        recordCaseData.checkSpecificCheckbox("Has Letter of Authority been received?");
+        recordCaseData.checkSpecificCheckbox("Yes");
         setSessionVariable("loaReceived").to("Yes");
         recordCaseData.enterDateIntoDateFieldsWithHeading(getTodaysDate(), "Date of Letter of Authority");
         setSessionVariable("loaReceivedDate").to(getTodaysDate());

--- a/src/test/java/com/hocs/test/pages/decs/BasePage.java
+++ b/src/test/java/com/hocs/test/pages/decs/BasePage.java
@@ -406,6 +406,10 @@ public class BasePage extends PageObject {
         return sessionVariableCalled("caseReference");
     }
 
+    public String getCaseTypeFromCaseReference(String caseReference) {
+        return caseReference.split("/")[0];
+    }
+
     public String getCurrentCaseReferenceFromTransferredCase(String newCaseType) {
         String newCaseRef = getCurrentCaseReference().replace(sessionVariableCalled("caseType"),newCaseType);
         setSessionVariable("newCaseReference").to(newCaseRef);
@@ -416,6 +420,7 @@ public class BasePage extends PageObject {
         String caseType = getCurrentCaseReference().split("/")[0];
         return caseType.toUpperCase();
     }
+
     public void safeClickOn(WebElementFacade webElementFacade) {
         webElementFacade.withTimeoutOf(Duration.ofSeconds(60)).waitUntilVisible().waitUntilClickable();
         try {

--- a/src/test/java/com/hocs/test/pages/managementUI/TeamManagement.java
+++ b/src/test/java/com/hocs/test/pages/managementUI/TeamManagement.java
@@ -98,7 +98,6 @@ public class TeamManagement extends BasePage {
 
     public void selectAUser(User user) {
         userSearchBar.withTimeoutOf(Duration.ofSeconds(10)).waitUntilVisible().clear();
-        userSearchBar.withTimeoutOf(Duration.ofSeconds(10)).waitUntilVisible().sendKeys(user.getAllocationText());
         WebElementFacade userOption = findBy("//div[contains(@class, 'govuk-typeahead__option')][text()='" + user.getAllocationText() + "']");
         userOption.withTimeoutOf(Duration.ofSeconds(30)).waitUntilClickable().click();
         waitABit(1000);

--- a/src/test/resources/features/cs/Deadlines.feature
+++ b/src/test/resources/features/cs/Deadlines.feature
@@ -67,28 +67,31 @@ Feature: Deadlines
     Then the case deadline date displayed in the summary is correct for a "Ex-Gratia" case
 
   @ComplaintsRegression1
-  Scenario: As a GRO Complaints user, when I have a Priority complaint, I expect the deadline to be 1 working day
-    When I get a "POGR" case at the "Data Input" stage
-    When I select "GRO" as the business area for the POGR case
+  Scenario Outline: As a GRO Complaints user, when I submit details about a Stage 1 complaint, I expect the deadline to be correct
+    And I get a "POGR" case at the "Data Input" stage
+    And I select "GRO" as the business area for the POGR case
     And I add a "Complainant" correspondent
     And I confirm the primary correspondent
-    And I record that the case is a Priority case
-    Then the case deadline date displayed in the summary is correct for a "Priority GRO complaint" case
+    When I record that the GRO case is a "<deadlineDefiningFactor>"
+    Then the case deadline date displayed in the summary is correct for a "<deadlineDefiningFactor>" case
+    Examples:
+      | deadlineDefiningFactor              |
+      | Priority GRO complaint              |
+      | non-Priority, non-Post GRO complaint |
+      | non-Priority, Post GRO complaint    |
 
   @ComplaintsRegression1
-  Scenario: As a GRO Complaints user, when I have a non-Prioirty complaint that wasnt receive by post, I expect the deadline to be 5 working days
-    When I get a "POGR" case at the "Data Input" stage
-    When I select "GRO" as the business area for the POGR case
+  Scenario Outline: As a GRO Complaints user, when I escalate a Stage 1 complaint to Stage 2, I expect the escalated case to have the correct deadline
+    And I get a "POGR" case at the "Data Input" stage
+    And I select "GRO" as the business area for the POGR case
     And I add a "Complainant" correspondent
     And I confirm the primary correspondent
-    And I record that the case was not received by post
-    Then the case deadline date displayed in the summary is correct for a "non-Priority, non-Post GRO complaint" case
-
-  @ComplaintsRegression1
-  Scenario: As a GRO Complaints user, when I have a non-Prioirty complaint that was receive by post, I expect the deadline to stay 10 working days
-    When I get a "POGR" case at the "Data Input" stage
-    When I select "GRO" as the business area for the POGR case
-    And I add a "Complainant" correspondent
-    And I confirm the primary correspondent
-    And I record that the case was received by post
-    Then the case deadline date displayed in the summary is correct for a "non-Priority, Post GRO complaint" case
+    And I record that the GRO case is a "<deadlineDefiningFactor>"
+    And I withdraw the case
+    And I escalate the closed case to Stage 2
+    Then the case deadline date displayed in the summary is correct for a "<deadlineDefiningFactor>" case
+    Examples:
+      | deadlineDefiningFactor              |
+      | Priority GRO complaint              |
+      | non-Priority, non-Post GRO complaint |
+      | non-Priority, Post GRO complaint    |


### PR DESCRIPTION
refactored CreateCase.java methods to make it easier to create a stage 2 case from a specific stage 1 case.
Added step for withdrawing a specific case.
Added scenarios to test GRO deadlines for stage 2 cases based on stage 1 case info.
Removed line from TeamManagement.selectAUser so it works better with the MUI typeaheads. Should make some scenarios less flaky.