### PR TITLE
HOCS-5455 HMPO Data Collection at Dispatch

### DIFF
--- a/src/test/java/com/hocs/test/glue/complaints/ComplaintsDispatchAndSendStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/ComplaintsDispatchAndSendStepDefs.java
@@ -36,4 +36,14 @@ public class ComplaintsDispatchAndSendStepDefs extends BasePage {
         waitForPageWithTitle("Complaint Send Response");
         complaintsDispatchAndSend.assertReasonsForComplaintAreVisible();
     }
+
+    @And("I select if a refund is required")
+    public void iSelectIfARefundIsRequired() {
+        complaintsDispatchAndSend.selectIfRefundRequired();
+    }
+
+    @And("I enter details of any Gratis offered")
+    public void iEnterDetailsOfAnyGratisOffered() {
+        complaintsDispatchAndSend.enterGratisOfferedDetails();
+    }
 }

--- a/src/test/java/com/hocs/test/pages/complaints/ComplaintsDispatchAndSend.java
+++ b/src/test/java/com/hocs/test/pages/complaints/ComplaintsDispatchAndSend.java
@@ -62,4 +62,20 @@ public class ComplaintsDispatchAndSend extends BasePage {
             }
         }
     }
+
+    public void selectIfRefundRequired() {
+        recordCaseData.selectRandomRadioButtonFromGroupWithHeading("Refund Required");
+    }
+
+    public void enterGratisOfferedDetails() {
+        String gratisOffered = recordCaseData.selectRandomRadioButtonFromGroupWithHeading("Gratis Offered");
+        if (gratisOffered.equalsIgnoreCase("YES")) {
+            recordCaseData.selectRandomOptionFromDropdownWithHeading("Document lost of damaged");
+            recordCaseData.selectRandomRadioButtonFromGroupWithHeading("Document replaced/replacement ordered");
+            String documentType = recordCaseData.selectRandomOptionFromDropdownWithHeading("Type of document lost or damaged");
+            if (documentType.equalsIgnoreCase("OTHER")) {
+                recordCaseData.enterTextIntoTextAreaWithHeading("Type of document lost or damage (other)");
+            }
+        }
+    }
 }

--- a/src/test/java/com/hocs/test/pages/complaints/ComplaintsTriageAndInvestigation.java
+++ b/src/test/java/com/hocs/test/pages/complaints/ComplaintsTriageAndInvestigation.java
@@ -220,10 +220,10 @@ public class ComplaintsTriageAndInvestigation extends BasePage {
 
     public void selectIsLoARequired() {
         String selectedOption = recordCaseData.selectRandomRadioButtonFromGroupWithHeading("Is a Letter of Authority required?");
+        setSessionVariable("isLoARequired").to(selectedOption);
         if ((bfCase() || bf2Case()) && selectedOption.equalsIgnoreCase("YES")) {
             enterLoAReceivedDetails();
         }
-        setSessionVariable("isLoARequired").to(selectedOption);
     }
 
     public void selectSpecificOptionForIsLOARequired(String yesNo) {
@@ -231,9 +231,14 @@ public class ComplaintsTriageAndInvestigation extends BasePage {
     }
 
     public void enterLoAReceivedDetails() {
-        recordCaseData.checkSpecificCheckbox("Yes");
+        if (pogrCase() || pogr2Case()) {
+            recordCaseData.checkSpecificCheckbox("Yes");
+            recordCaseData.enterDateIntoDateFieldsWithHeading(getTodaysDate(), "Letter of Authority Date Received");
+        } else {
+            recordCaseData.checkSpecificCheckbox("Has Letter of Authority been received?");
+            recordCaseData.enterDateIntoDateFieldsWithHeading(getTodaysDate(), "Date of Letter of Authority");
+        }
         setSessionVariable("loaReceived").to("Yes");
-        recordCaseData.enterDateIntoDateFieldsWithHeading(getTodaysDate(), "Letter of Authority Date Received");
         setSessionVariable("loaReceivedDate").to(getTodaysDate());
     }
 

--- a/src/test/java/com/hocs/test/pages/complaints/ComplaintsTriageAndInvestigation.java
+++ b/src/test/java/com/hocs/test/pages/complaints/ComplaintsTriageAndInvestigation.java
@@ -233,7 +233,7 @@ public class ComplaintsTriageAndInvestigation extends BasePage {
     public void enterLoAReceivedDetails() {
         recordCaseData.checkSpecificCheckbox("Yes");
         setSessionVariable("loaReceived").to("Yes");
-        recordCaseData.enterDateIntoDateFieldsWithHeading(getTodaysDate(), "Date of Letter of Authority");
+        recordCaseData.enterDateIntoDateFieldsWithHeading(getTodaysDate(), "Letter of Authority Date Received");
         setSessionVariable("loaReceivedDate").to(getTodaysDate());
     }
 

--- a/src/test/java/com/hocs/test/pages/decs/BasePage.java
+++ b/src/test/java/com/hocs/test/pages/decs/BasePage.java
@@ -700,9 +700,9 @@ public class BasePage extends PageObject {
     }
 
     public void checkSpecificCheckbox(String checkboxLabelText) {
-        WebElementFacade checkbox =
-                findBy("//input[@type='checkbox']/following-sibling::label[text()=" + sanitiseXpathAttributeString(checkboxLabelText) + "]");
-        safeClickOn(checkbox);
+        List<WebElementFacade> checkboxElements =
+                findAll("//input[@type='checkbox']/following-sibling::label[text()=" + sanitiseXpathAttributeString(checkboxLabelText) + "]");
+        safeClickOn(getOnlyCurrentlyVisibleElementFromList(checkboxElements));
     }
 
     public boolean checkboxWithLabelIsCurrentlyVisible(String checkboxLabelText) {

--- a/src/test/java/com/hocs/test/pages/decs/CreateCase.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase.java
@@ -135,7 +135,7 @@ public class CreateCase extends BasePage {
 
     Boolean specificStage1CaseProvided = false;
 
-    String stage1CaseReference;
+    String stage1CaseReference = "";
 
     // Basic Methods
 

--- a/src/test/resources/features/complaints/ComplaintsDispatch&Send.feature
+++ b/src/test/resources/features/complaints/ComplaintsDispatch&Send.feature
@@ -117,14 +117,20 @@ Feature: Complaints Dispatch & Send
 
 #     POGR COMPLAINTS
 
-  Scenario Outline: User can complete the Dispatch stage for a POGR complaint case
+  Scenario: User can complete the Dispatch stage for a HMPO POGR complaint case
     Given I am logged into "CS" as user "POGR_USER"
-    When I get a POGR case with "<businessArea>" as the Business Area at the "Dispatch" stage
+    When I get a POGR case with "HMPO" as the Business Area at the "Dispatch" stage
+    And I add a "Final Response" type document to the case
+    And I select a Dispatch Outcome
+    And I select if a refund is required
+    And I enter details of any Gratis offered
+    And I submit the Response details
+    Then the case should be closed
+
+  Scenario: User can complete the Dispatch stage for a GRO POGR complaint case
+    Given I am logged into "CS" as user "POGR_USER"
+    When I get a POGR case with "GRO" as the Business Area at the "Dispatch" stage
     And I add a "Final Response" type document to the case
     And I select a Dispatch Outcome
     And I submit the Response details
     Then the case should be closed
-    Examples:
-    | businessArea  |
-    | HMPO          |
-    | GRO           |


### PR DESCRIPTION
Added in logic for new Dispatch fields for HMPO POGR cases.
Amended basepage method for selecting a specific checkbox so it can handle when there are hidden checkboxes on a page with a matching label.
Corrected some headers for fields in the POGR Investigation stage.