### PR TITLE
HOCS-5544 IEDET: PSU Registration

### DIFF
--- a/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/ComplaintsRegistrationAndDataInputStepDefs.java
@@ -21,7 +21,7 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
 
     @And("I enter the Complainant Details")
     public void iEnterTheComplainantDetails() {
-          complaintsRegistrationAndDataInput.enterComplainantDetails();
+        complaintsRegistrationAndDataInput.enterComplainantDetails();
     }
 
     @And("I select {string} as the Complaint Type")
@@ -31,7 +31,7 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
 
     @And("I enter the complaint details on the Complaint Input page")
     public void iEnterTheComplaintDetailsOnTheComplaintInputPage() {
-        if(!iedetCase()) {
+        if (!iedetCase()) {
             complaintsRegistrationAndDataInput.selectAComplaintChannel();
         }
         if (iedetCase() | smcCase()) {
@@ -50,7 +50,7 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
 
     @And("I select a {string} Complaint Category")
     public void iSelectAComplaintCategory(String complaintCategory) {
-        if(!iedetCase()){
+        if (!iedetCase()) {
             switch (complaintCategory.toUpperCase()) {
                 case "SERVICE":
                     complaintsRegistrationAndDataInput.openTheServiceComplaintCategoryAccordion();
@@ -66,12 +66,12 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
                     break;
                 default:
                     pendingStep(complaintCategory + " is not defined within " + getMethodName());
-        }
+            }
             waitABit(1000);
             complaintsRegistrationAndDataInput.selectAVisibleClaimCategory();
-        }
-        else {
+        } else {
             complaintsTriageAndInvestigation.selectIEDETClaimCategory(complaintCategory);
+            clickTheButton("Continue");
         }
     }
 
@@ -137,5 +137,20 @@ public class ComplaintsRegistrationAndDataInputStepDefs extends BasePage {
         }
         safeClickOn(continueButton);
         waitABit(1000);
+    }
+
+    @And("I escalate the case to PSU")
+    public void iEscalateTheCaseToPSU() {
+        complaintsRegistrationAndDataInput.selectASpecificComplaintType("Serious misconduct");
+        complaintsTriageAndInvestigation.selectIEDETClaimCategory("Serious misconduct");
+        clickTheButton("Continue");
+        iEnterTheComplaintDetailsOnTheComplaintInputPage();
+        clickTheButton("Finish and escalate to PSU");
+    }
+
+    @And("I submit a PSU reference")
+    public void iSubmitAPSUReference() {
+        complaintsRegistrationAndDataInput.enterAPSUReference();
+        clickTheButton("Submit");
     }
 }

--- a/src/test/java/com/hocs/test/glue/complaints/ComplaintsTriageAndInvestigationStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/complaints/ComplaintsTriageAndInvestigationStepDefs.java
@@ -4,6 +4,7 @@ import static jnr.posix.util.MethodName.getMethodName;
 import static net.serenitybdd.core.Serenity.pendingStep;
 import static net.serenitybdd.core.Serenity.sessionVariableCalled;
 
+import com.hocs.test.pages.complaints.ComplaintsRegistrationAndDataInput;
 import com.hocs.test.pages.decs.BasePage;
 import com.hocs.test.pages.complaints.ComplaintsTriageAndInvestigation;
 import io.cucumber.java.en.And;
@@ -277,5 +278,10 @@ public class ComplaintsTriageAndInvestigationStepDefs extends BasePage {
     @And("I select a Closure Reason")
     public void iSelectAClosureReason() {
         complaintsTriageAndInvestigation.selectAClosureReason();
+    }
+
+    @And("I complete Triage and escalate the case to PSU")
+    public void iCompleteTriageAndEscalateTheCaseToPSU() {
+        clickTheButton("Finish and escalate to PSU");
     }
 }

--- a/src/test/java/com/hocs/test/glue/decs/ProgressCaseStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/ProgressCaseStepDefs.java
@@ -64,7 +64,7 @@ public class ProgressCaseStepDefs extends BasePage {
                 compProgressCase.completeTheCOMPStageSoThatCaseMovesToTargetStage(stage, "N/A");
                 break;
             case "IEDET":
-                iedetProgressCase.completeTheIEDETStage(stage);
+                iedetProgressCase.completeTheIEDETStage(stage,  "Happy Path");
                 break;
             case "SMC":
                 smcProgressCase.completeTheSMCStage(stage);
@@ -143,7 +143,7 @@ public class ProgressCaseStepDefs extends BasePage {
         iMoveTheCaseFromCurrentStageToTargetStage("N/A", targetStage);
     }
 
-    @And("I get a {string} case/claim at (the ){string}( stage)")
+    @And("I get a/an {string} case/claim at (the ){string}( stage)")
     public void iGetACaseAtAStage(String caseType, String stage) {
         iCreateACaseAndMoveItToAStage(caseType, stage);
         if (stage.equalsIgnoreCase("CASE CLOSED") || previousStageWouldHaveAutoAllocated(caseType, stage)) {

--- a/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
+++ b/src/test/java/com/hocs/test/glue/decs/SummaryTabStepDefs.java
@@ -229,6 +229,11 @@ public class SummaryTabStepDefs extends BasePage {
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("stopList"), "Stop List name");
     }
 
+    @And("the summary should contain the PSU reference")
+    public void theSummaryShouldContainThePSUReference() {
+        summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("psuReference"), "PSU reference");
+    }
+
     @And("the closure reason and details should be visible in the Summary tab")
     public void theClosureReasonAndDetailsShouldBeVisibleInTheSummaryTab() {
         summaryTab.assertSummaryContainsExpectedValueForGivenHeader(sessionVariableCalled("closureReason"), "Why should this case be closed?");

--- a/src/test/java/com/hocs/test/pages/complaints/ComplaintsRegistrationAndDataInput.java
+++ b/src/test/java/com/hocs/test/pages/complaints/ComplaintsRegistrationAndDataInput.java
@@ -61,36 +61,13 @@ public class ComplaintsRegistrationAndDataInput extends BasePage {
 
     }
 
-    //TODO Refactor below if statements once the queries are answered in HOCS-5498
     public void selectASpecificComplaintType(String complaintType) {
-        switch (complaintType.toUpperCase()) {
-            case "SERVICE":
-                if(iedetCase()){
-                    recordCaseData.selectSpecificRadioButton( "Service");
-                } else {
-                    recordCaseData.selectSpecificRadioButtonFromGroupWithHeading("Service", "Complaint Type");
-                }
-                setSessionVariable("complaintType").to("Service");
-                break;
-            case "MINOR MISCONDUCT":
-                if(iedetCase()){
-                    recordCaseData.selectSpecificRadioButton( "Minor Misconduct");
-                } else {
-                    recordCaseData.selectSpecificRadioButtonFromGroupWithHeading("Minor Misconduct", "Complaint Type");
-                }
-                setSessionVariable("complaintType").to("Minor Misconduct");
-                break;
-            case "EX-GRATIA":
-                if(iedetCase()){
-                    recordCaseData.selectSpecificRadioButton( "Ex-Gratia");
-                } else {
-                    recordCaseData.selectSpecificRadioButtonFromGroupWithHeading("Ex-Gratia", "Complaint Type");
-                }
-                setSessionVariable("complaintType").to("Ex-Gratia");
-                break;
-            default:
-                pendingStep(complaintType + " is not defined within " + getMethodName());
+        if(iedetCase()){
+            recordCaseData.selectSpecificRadioButton(complaintType);
+        } else {
+            recordCaseData.selectSpecificRadioButtonFromGroupWithHeading(complaintType, "Complaint Type");
         }
+        setSessionVariable("complaintType").to("Service");
         clickTheButton("Continue");
         System.out.println("Complaint type: " + complaintType);
     }
@@ -297,5 +274,10 @@ public class ComplaintsRegistrationAndDataInput extends BasePage {
         }
         clickTheButton("Continue");
         waitForPageWithTitle("Complaint Correspondents");
+    }
+
+    public void enterAPSUReference() {
+        String psuReference = recordCaseData.enterTextIntoTextFieldWithHeading("PSU reference");
+        setSessionVariable("psuReference").to(psuReference);
     }
 }

--- a/src/test/java/com/hocs/test/pages/complaints/IEDETProgressCase.java
+++ b/src/test/java/com/hocs/test/pages/complaints/IEDETProgressCase.java
@@ -41,7 +41,7 @@ public class IEDETProgressCase extends BasePage {
             if (!precedingStage.equalsIgnoreCase(currentStage)) {
                 moveCaseFromCurrentStageToTargetStage(currentStage, precedingStage);
             }
-            completeTheIEDETStage(precedingStage);
+            completeTheIEDETStage(precedingStage, targetStage);
         }
     }
 
@@ -55,6 +55,7 @@ public class IEDETProgressCase extends BasePage {
                 precedingStage = "REGISTRATION";
                 break;
             case "DRAFT":
+            case "PSU REGISTRATION":
                 precedingStage = "TRIAGE";
                 break;
             case "SEND":
@@ -69,14 +70,24 @@ public class IEDETProgressCase extends BasePage {
         return precedingStage;
     }
 
-    public void completeTheIEDETStage(String stageToComplete) {
+    public void completeTheIEDETStage(String stageToComplete, String targetStage) {
         dashboard.ensureCurrentCaseIsLoadedAndAllocatedToCurrentUser();
         switch (stageToComplete.toUpperCase()) {
             case "REGISTRATION":
                 moveIEDETCaseFromRegistrationToTriage();
                 break;
             case "TRIAGE":
-                moveIEDETCaseFromTriageToDraft();
+                switch (targetStage.toUpperCase()) {
+                    case "DRAFT":
+                    case "HAPPY PATH":
+                        moveIEDETCaseFromTriageToDraft();
+                        break;
+                    case "PSU REGISTRATION":
+                        moveIEDETCaseFromTriageToPSURegistration();
+                        break;
+                    default:
+                        pendingStep(targetStage + " is not defined within " + getMethodName());
+                }
                 break;
             case "DRAFT":
                 moveIEDETCaseFromDraftToSend();
@@ -111,6 +122,16 @@ public class IEDETProgressCase extends BasePage {
         complaintsTriageAndInvestigation.selectIEDETBusinessArea();
         clickTheButton("Finish");
         System.out.println("Case moved from Triage to Draft");
+    }
+
+    private void moveIEDETCaseFromTriageToPSURegistration() {
+        complaintsRegistrationAndDataInput.selectASpecificComplaintType("Serious misconduct");
+        complaintsTriageAndInvestigation.selectIEDETClaimCategory("Serious misconduct");
+        clickTheButton("Continue");
+        complaintsRegistrationAndDataInput.selectComplaintOrigin();
+        complaintsRegistrationAndDataInput.enterADescriptionOfTheComplaint();
+        complaintsRegistrationAndDataInput.enterAThirdPartyReference();
+        clickTheButton("Finish and escalate to PSU");
     }
 
     public void moveIEDETCaseFromDraftToSend() {

--- a/src/test/resources/features/complaints/ComplaintsTriageAndInvestigation.feature
+++ b/src/test/resources/features/complaints/ComplaintsTriageAndInvestigation.feature
@@ -309,7 +309,6 @@ Feature: Complaints Triage
     And I load and claim the current case
     And I select "Service" as the Complaint Type
     And I select a "Service" Complaint Category
-    And I click the "Continue" button
     And I enter the complaint details on the Complaint Input page
     And I click the "Continue" button
     And I select the "<investigationTeam>" action for an IEDET case at the Triage stage
@@ -317,19 +316,44 @@ Feature: Complaints Triage
     And the summary should display the owning team as "IE Detention"
     And the read-only Case Details accordion should contain all case information entered during the "Triage" stage
     Examples:
-      | investigationTeam           |
-      | Third party supplier        |
-      | IE Detention compliance team|
-      | DEPMU                       |
+      | investigationTeam            |
+      | Third party supplier         |
+      | IE Detention compliance team |
+      | DEPMU                        |
 
   # Expected failure. Defect HOCS-5635 raised.
-  @IEDETAndSMCRegression @IEDETComplaints
+  @ComplaintsWorkflow @IEDETAndSMCRegression @IEDETComplaints
   Scenario: User can transfer a IEDET complaints case to CCH
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to the "Triage" stage
     And I load and claim the current case
     And I select the "Send to CCH" action for an IEDET case at the Triage stage
     Then the case should be closed
+
+  # Expected failure. Defect HOCS-5632 raised.
+  @ComplaintsWorkflow @IEDETAndSMCRegression @IEDETComplaints
+  Scenario: As an IEDET complaints user, I can escalate a case to PSU, so that the correct team can casework the case
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I get an "IEDET" case at "Triage" stage
+    And I select "Serious misconduct" as the Complaint Type
+    And I select a "Serious misconduct" Complaint Category
+    And I enter the complaint details on the Complaint Input page
+    And I complete Triage and escalate the case to PSU
+    Then the case should be moved to the "PSU Registration" stage
+    And the summary should display the owning team as "PSU Complaints"
+    And the read-only Case Details accordion should contain all case information entered during the "Triage" stage
+
+  # will fail until HOCS-5544 is reworked to meet all AC
+  @ComplaintsWorkflow @IEDETAndSMCRegression @IEDETComplaints
+  Scenario: As a PSU complaints user, I can register a complaint escalated by IEDET, so that the case can progress
+    Given I am logged into "CS" as user "IEDET_USER"
+    When I create a "IEDET" case and move it to the "PSU Registration" stage
+    And I switch to user "SMC_USER"
+    And I load and claim the current case
+    And I submit a PSU reference
+    Then the case should be moved to the "PSU Triage" stage
+    And the summary should contain the PSU reference
+    And the read-only Case Details accordion should contain all case information entered during the "PSU Registration" stage
 
 
 #     SMC COMPLAINTS
@@ -417,11 +441,11 @@ Feature: Complaints Triage
     And I "<action>" the contribution request
     Then the "<contributionType>" contribution request should be marked as "<action>"
     Examples:
-    | contributionType  | action    |
-    | Complainant       | Complete  |
-    | Complainant       | Cancel    |
-    | Business          | Complete  |
-    | Business          | Cancel    |
+      | contributionType | action   |
+      | Complainant      | Complete |
+      | Complainant      | Cancel   |
+      | Business         | Complete |
+      | Business         | Cancel   |
 
   @BFRegression @BFComplaints
   Scenario: User is able to add Consolatory and Ex-Gratia payment offers to a BF case at Triage
@@ -485,11 +509,11 @@ Feature: Complaints Triage
     And I "<action>" the contribution request
     Then the "<contributionType>" contribution request should be marked as "<action>"
     Examples:
-      | contributionType  | action    |
-      | Complainant       | Complete  |
-      | Complainant       | Cancel    |
-      | Business          | Complete  |
-      | Business          | Cancel    |
+      | contributionType | action   |
+      | Complainant      | Complete |
+      | Complainant      | Cancel   |
+      | Business         | Complete |
+      | Business         | Cancel   |
 
   @BFRegression @BFComplaints
   Scenario: User is able to add Consolatory and Ex-Gratia payment offers to a BF2 case at Triage


### PR DESCRIPTION
Added scenario's and associated steps/methods for IEDET escalation to PSU Registration and PSU Registration stage.
Added PSU Registration to IEDETProgressCase, and amended IEDETProgressCase.completeTheIEDETStage method to take a target stage parameter. Refactored ComplaintsRegistrationAndDataInput.selectASpecificComplaintType, removing the switch case. Step now required the correct text casing of the complaint type parameter to be passed in.