### PR TITLE
Deprecate SMC workflow

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -482,7 +482,7 @@ services:
 ---
 kind: pipeline
 type: kubernetes
-name: IEDET-SMC-Regression
+name: IEDET-Regression
 depends_on:
   - SMOKE
 trigger:
@@ -495,7 +495,7 @@ steps:
   - name: execute tests
     image: quay.io/ukhomeofficedigital/hocs-serenity-automation:${DRONE_COMMIT_SHA}
     commands:
-      - sh bin/iedetandsmc.sh
+      - sh bin/iedet.sh
     environment:
       ARTIFACTORY_PASSWORD:
         from_secret: artifactory_password
@@ -506,7 +506,7 @@ steps:
     commands:
       - > # yaml folded style
         aws s3 cp
-        --recursive /drone/src/target/site/serenity/ s3://cs-integration-testing-s3/serenity-reports/$${DRONE_BUILD_NUMBER}_IEDET_SMC/
+        --recursive /drone/src/target/site/serenity/ s3://cs-integration-testing-s3/serenity-reports/$${DRONE_BUILD_NUMBER}_IEDET/
         --sse aws:kms
         --sse-kms-key-id $${AWS_KMS_KEY}
     environment:

--- a/bin/iedet.sh
+++ b/bin/iedet.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mvn clean verify -B -Dcucumber.filter.tags="@IEDETRegression" -Dwebdriver.remote.url=http://selenium:4444/wd/hub -e -Dwebdriver.remote
+.driver=chrome

--- a/bin/iedetandsmc.sh
+++ b/bin/iedetandsmc.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-mvn clean verify -B -Dcucumber.filter.tags="@IEDETAndSMCRegression" -Dwebdriver.remote.url=http://selenium:4444/wd/hub -e -Dwebdriver.remote
-.driver=chrome

--- a/src/test/java/com/hocs/test/pages/decs/CreateCase.java
+++ b/src/test/java/com/hocs/test/pages/decs/CreateCase.java
@@ -247,7 +247,7 @@ public class CreateCase extends BasePage {
     }
 
     public String getRandomCSCaseType() {
-        List<String> list = Arrays.asList("MIN", "TRO", "DTEN", "MPAM", "MTS", "COMP", "IEDET", "SMC", "TO", "BF", "POGR");
+        List<String> list = Arrays.asList("MIN", "TRO", "DTEN", "MPAM", "MTS", "COMP", "COMP2", "IEDET", "TO", "BF", "BF2", "POGR", "POGR2");
         return list.get(new Random().nextInt(list.size()));
     }
 
@@ -257,7 +257,7 @@ public class CreateCase extends BasePage {
     }
 
     public String getRandomComplaintsCaseType() {
-        List<String> list = Arrays.asList("COMP", "COMP2", "SMC", "IEDET", "BF", "POGR");
+        List<String> list = Arrays.asList("COMP", "COMP2", "IEDET", "BF", "BF2", "POGR", "POGR2");
         return list.get(new Random().nextInt(list.size()));
     }
 

--- a/src/test/java/com/hocs/test/pages/decs/Documents.java
+++ b/src/test/java/com/hocs/test/pages/decs/Documents.java
@@ -323,7 +323,6 @@ public class Documents extends BasePage {
                 break;
             case "COMP":
             case "COMP2":
-            case "SMC":
                 requiredDocumentTypes.addAll(Arrays.asList("To document", "Public correspondence", "Complaint leaflet", "Complaint letter", "Email"
                         , "CRF", "DRAFT", "Appeal Leaflet", "IMB Letter", "Final Response"));
                 break;

--- a/src/test/java/com/hocs/test/pages/decs/SummaryTab.java
+++ b/src/test/java/com/hocs/test/pages/decs/SummaryTab.java
@@ -200,7 +200,6 @@ public class SummaryTab extends BasePage {
                     expectedNumberOfWorkdaysTillDeadline = 20;
                     break;
                 case "EX-GRATIA":
-                case "SMC":
                     expectedNumberOfWorkdaysTillDeadline = 60;
                     break;
                 default:

--- a/src/test/resources/features/complaints/Actions.feature
+++ b/src/test/resources/features/complaints/Actions.feature
@@ -1,6 +1,8 @@
 @ComplaintsActions @Complaints
 Feature: Actions
 
+#      BF COMPLAINTS
+
   # HOCS-4395, HOCS-4396, HOCS-5437
   @BFRegression @BFComplaints
   Scenario: User is able to add and update a Registered Interest in a Border Force Complaints case
@@ -32,7 +34,12 @@ Feature: Actions
     And the updated details of the interest should be visible in the actions tab
     And an Interest Updated log should be visible in the timeline for the interested party
 
-  @IEDETAndSMCRegression @SMCComplaints
+
+#  SMC workflow cancelled. Steps and code might be useful for future work implementing PSU specific sub-workflow into other complaints workflows
+
+#     SMC COMPLAINTS
+
+  @SMCComplaints
   Scenario: As a SMC caseworker, I want to be able to suspend a case, so that the case and its SLA reflect its current status
     Given I am logged into "CS" as user "SMC_USER"
     And I get a new "SMC" case
@@ -45,7 +52,7 @@ Feature: Actions
     And the deadline of the case should be replaced with the word "Suspended" in the "SMC Registration" workstack
     And the deadline of the case should be replaced with the word "Suspended" in the My Cases workstack
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC caseworker, I want to be able to remove the suspension on a case, so that the case reflect its current status
     Given I am logged into "CS" as user "SMC_USER"
     And I get a new "SMC" case

--- a/src/test/resources/features/complaints/ComplaintsDispatch&Send.feature
+++ b/src/test/resources/features/complaints/ComplaintsDispatch&Send.feature
@@ -66,24 +66,12 @@ Feature: Complaints Dispatch & Send
 
 #     IEDET COMPLAINTS
 
-  @ComplaintsWorkflow @IEDETAndSMCRegression @IEDETComplaints
+  @ComplaintsWorkflow @IEDETRegression @IEDETComplaints
   Scenario: User can complete the Send stage for an IEDET complaint case
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to the "Send" stage
     And I load the current case
     And I upload a copy of the Final Response
-    And I select a Case Outcome
-    And I submit the Response details
-    Then the case should be closed
-
-
-#     SMC COMPLAINTS
-
-  @ComplaintsPWorkflow @IEDETAndSMCRegression @SMCComplaints
-  Scenario: User can complete the Send stage for an SMC complaint case
-    Given I am logged into "CS" as user "SMC_USER"
-    When I get a "SMC" case at the "Send" stage
-    And I add a "Final Response" type document to the case
     And I select a Case Outcome
     And I submit the Response details
     Then the case should be closed
@@ -153,8 +141,7 @@ Feature: Complaints Dispatch & Send
     And I enter details of any Gratis offered
     And I submit the Response details
     Then the case should be closed
-#    And the read-only Case Details accordion should contain all case information entered during the "Dispatch" stage
-# Remove comment above once HOCS-5570 is resolved
+    And the read-only Case Details accordion should contain all case information entered during the "Dispatch" stage
 
   @ComplaintsWorkflow @POGRRegression @POGRComplaints
   Scenario: User can complete the Dispatch stage for a GRO POGR stage 2 complaint case
@@ -164,5 +151,18 @@ Feature: Complaints Dispatch & Send
     And I select a Dispatch Outcome
     And I submit the Response details
     Then the case should be closed
-#    And the read-only Case Details accordion should contain all case information entered during the "Dispatch" stage
-# Remove comment above once HOCS-5570 is resolved
+    And the read-only Case Details accordion should contain all case information entered during the "Dispatch" stage
+
+
+#  SMC workflow cancelled. Steps and code might be useful for future work implementing PSU specific sub-workflow into other complaints workflows
+
+#     SMC COMPLAINTS
+
+  @ComplaintsPWorkflow @SMCComplaints
+  Scenario: User can complete the Send stage for an SMC complaint case
+    Given I am logged into "CS" as user "SMC_USER"
+    When I get a "SMC" case at the "Send" stage
+    And I add a "Final Response" type document to the case
+    And I select a Case Outcome
+    And I submit the Response details
+    Then the case should be closed

--- a/src/test/resources/features/complaints/ComplaintsDraft.feature
+++ b/src/test/resources/features/complaints/ComplaintsDraft.feature
@@ -174,7 +174,7 @@ Feature: Complaints Draft
 
 #     IEDET COMPLAINTS
 
-  @ComplaintsWorkflow @IEDETAndSMCRegression @IEDETComplaints
+  @ComplaintsWorkflow @IEDETRegression @IEDETComplaints
   Scenario: User completes the Draft stage for an IEDET complaint case
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to the "Draft" stage
@@ -182,20 +182,6 @@ Feature: Complaints Draft
     And I click the "Proceed to recording outcome" button
     Then the case should be moved to the "Send" stage
     And the summary should display the owning team as "IE Detention"
-
-
-#     SMC COMPLAINTS
-
-  @ComplaintsWorkflow @IEDETAndSMCRegression @SMCComplaints
-  Scenario: User completes the Draft stage for an SMC complaint case
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Draft" stage
-    And I load and claim the current case
-    And I upload my Primary "DRAFT" document
-    And I click the "Response Ready" button
-    Then the case should be moved to the "Send" stage
-    And the summary should display the owning team as "Serious Misconduct"
-    And the selected document should be tagged as the primary draft
 
 
 #     BF COMPLAINTS
@@ -497,3 +483,19 @@ Feature: Complaints Draft
       | businessArea |
       | HMPO         |
       | GRO          |
+
+
+#  SMC workflow cancelled. Steps and code might be useful for future work implementing PSU specific sub-workflow into other complaints workflows
+
+#     SMC COMPLAINTS
+
+  @ComplaintsWorkflow @SMCComplaints
+  Scenario: User completes the Draft stage for an SMC complaint case
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Draft" stage
+    And I load and claim the current case
+    And I upload my Primary "DRAFT" document
+    And I click the "Response Ready" button
+    Then the case should be moved to the "Send" stage
+    And the summary should display the owning team as "Serious Misconduct"
+    And the selected document should be tagged as the primary draft

--- a/src/test/resources/features/complaints/ComplaintsEndToEnd.feature
+++ b/src/test/resources/features/complaints/ComplaintsEndToEnd.feature
@@ -178,37 +178,10 @@ Feature: Complaints End To End
     When I create a "IEDET" case and move it to the "Send" stage
     Then the case should be moved to the "Send" stage
 
-  @IEDETAndSMCRegression @IEDETComplaints
+  @IEDETRegression @IEDETComplaints
   Scenario: User is able to close an IEDET complaint case
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to "Case Closed"
-    Then the case should be closed
-
-
-#     SMC COMPLAINTS
-
-  @SMCComplaints
-  Scenario: User creates a SMC complaint case and it starts at the Registration stage
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Registration" stage
-    Then the case should be moved to the "Registration" stage
-
-  @SMCComplaints
-  Scenario: User moves an SMC complaint case to the Triage stage
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Triage" stage
-    Then the case should be moved to the "Triage" stage
-
-  @SMCComplaints
-  Scenario: User moves an SMC complaint case to the Send stage
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Send" stage
-    Then the case should be moved to the "Send" stage
-
-  @IEDETAndSMCRegression @SMCComplaints
-  Scenario: User is able to close an SMC complaint case
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to "Case Closed"
     Then the case should be closed
 
 
@@ -400,4 +373,33 @@ Feature: Complaints End To End
   Scenario: User is able to close a POGR stage 2 complaint case
     Given I am logged into "CS" as user "POGR_USER"
     When I create a "POGR2" case and move it to the "Case Closed" stage
+    Then the case should be closed
+
+
+#  SMC workflow cancelled. Steps and code might be useful for future work implementing PSU specific sub-workflow into other complaints workflows
+
+#     SMC COMPLAINTS
+
+  @SMCComplaints
+  Scenario: User creates a SMC complaint case and it starts at the Registration stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Registration" stage
+    Then the case should be moved to the "Registration" stage
+
+  @SMCComplaints
+  Scenario: User moves an SMC complaint case to the Triage stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Triage" stage
+    Then the case should be moved to the "Triage" stage
+
+  @SMCComplaints
+  Scenario: User moves an SMC complaint case to the Send stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Send" stage
+    Then the case should be moved to the "Send" stage
+
+  @SMCComplaints
+  Scenario: User is able to close an SMC complaint case
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to "Case Closed"
     Then the case should be closed

--- a/src/test/resources/features/complaints/ComplaintsRegistration&DataInput.feature
+++ b/src/test/resources/features/complaints/ComplaintsRegistration&DataInput.feature
@@ -111,7 +111,7 @@ Feature: Registration
 
 #     IEDET COMPLAINTS
 
-  @ComplaintsWorkflow @IEDETAndSMCRegression @IEDETComplaints
+  @ComplaintsWorkflow @IEDETRegression @IEDETComplaints
   Scenario: User can complete the Registration stage for an IEDET complaint case
     Given I am logged into "CS" as user "IEDET_USER"
     And I create a single "IEDET" case
@@ -122,26 +122,6 @@ Feature: Registration
     Then the case should be moved to the "Triage" stage
     And the summary should display the owning team as "IE Detention"
     And the read-only Case Details accordion should contain all case information entered during the "IEDET Registration" stage
-
-
-#     SMC COMPLAINTS
-
-  @ComplaintsWorkflow @IEDETAndSMCRegression @SMCComplaints
-  Scenario: User is able to complete the Registration stage for an SMC complaint case
-    Given I am logged into "CS" as user "SMC_USER"
-    And I create a single "SMC" case
-    And I allocate the case to myself via the successful case creation screen
-    And I add a "Complainant" correspondent
-    And I click the "Continue" button
-    And I enter the Complainant Details
-    And I enter the complaint details on the Complaint Input page
-    And I click the "Continue" button
-    And I select a "Serious" Complaint Category
-    And I select a Owning CSU
-    And I click the "Finish" button
-    Then the case should be moved to the "Triage" stage
-    And the summary should display the owning team as "Serious Misconduct"
-    And the read-only Case Details accordion should contain all case information entered during the "Registration" stage
 
 
 #     BF COMPLAINTS
@@ -233,7 +213,7 @@ Feature: Registration
     And I enter the date that the Interim letter was sent
     Then the case should be moved to the "Investigation" stage
     And the summary should display the owning team as "HMPO Complaints"
-#    And the read-only Case Details accordion should contain all case information entered during the "Data Input" stage
+    And the read-only Case Details accordion should contain all case information entered during the "Data Input" stage
 
   @ComplaintsWorkflow @ComplaintsRegression2 @POGRComplaints
   Scenario: User is able to complete the Data Input stage for a POGR stage 2 complaint case with GRO as the business area
@@ -247,4 +227,26 @@ Feature: Registration
     And I select the investigating team for the case
     Then the case should be moved to the "Investigation" stage
     And the POGR case should be assigned to the correct investigating team
-#    And the read-only Case Details accordion should contain all case information entered during the "Data Input" stage
+    And the read-only Case Details accordion should contain all case information entered during the "Data Input" stage
+
+
+#  SMC workflow cancelled. Steps and code might be useful for future work implementing PSU specific sub-workflow into other complaints workflows
+
+#     SMC COMPLAINTS
+
+  @ComplaintsWorkflow @SMCComplaints
+  Scenario: User is able to complete the Registration stage for an SMC complaint case
+    Given I am logged into "CS" as user "SMC_USER"
+    And I create a single "SMC" case
+    And I allocate the case to myself via the successful case creation screen
+    And I add a "Complainant" correspondent
+    And I click the "Continue" button
+    And I enter the Complainant Details
+    And I enter the complaint details on the Complaint Input page
+    And I click the "Continue" button
+    And I select a "Serious" Complaint Category
+    And I select a Owning CSU
+    And I click the "Finish" button
+    Then the case should be moved to the "Triage" stage
+    And the summary should display the owning team as "Serious Misconduct"
+    And the read-only Case Details accordion should contain all case information entered during the "Registration" stage

--- a/src/test/resources/features/complaints/ComplaintsSearch.feature
+++ b/src/test/resources/features/complaints/ComplaintsSearch.feature
@@ -99,7 +99,7 @@ Feature: Complaints Search
 
 #     IEDET COMPLAINTS
 
-  @IEDETAndSMCRegression @IEDETComplaints
+  @IEDETRegression @IEDETComplaints
   Scenario Outline: User tests IEDET complaint case search criteria
     Given I am logged into "CS" as user "IEDET_USER"
     When I navigate to the "Search" page
@@ -114,36 +114,10 @@ Feature: Complaints Search
       | Complainant Date Of Birth         | 01/01/2001                           |
       | Complainant Home Office Reference | Test entry for Home Office Reference |
 
-  @IEDETAndSMCRegression @IEDETComplaints
+  @IEDETRegression @IEDETComplaints
   Scenario: User can search for a IEDET complaint case by its case reference
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a single "IEDET" case
-    And I search for the case by its case reference
-    Then the created case should be the only case visible in the search results
-
-
-#     SMC COMPLAINTS
-
-  @IEDETAndSMCRegression @SMCComplaints
-  Scenario Outline: User tests SMC complaint case search criteria
-    Given I am logged into "CS" as user "SMC_USER"
-    When I navigate to the "Search" page
-    And I enter "<infoValue>" into the "<infoType>" search field in the "SMC" search configuration
-    And I click the search button on the search page
-    Then I check that the search results have the correct "<infoType>"
-    Examples:
-      | infoType                          | infoValue                             |
-      | Correspondent full name           | Sam McTester                          |
-      | Correspondent postcode            | AB1 2CD                               |
-      | Correspondent email address       | SamMcTester@Test.com                  |
-      | Complainant date of birth         | 01/01/2001                            |
-      | Complainant Home Office Reference | Test entry for Home Office Reference  |
-      | PSU Reference                     | 123456789                             |
-
-  @IEDETAndSMCRegression @SMCComplaints
-  Scenario: User can search for a SMC complaint case by its case reference
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a single "SMC" case
     And I search for the case by its case reference
     Then the created case should be the only case visible in the search results
 
@@ -182,3 +156,31 @@ Feature: Complaints Search
     And I search for the complaints case escalated to stage 2 by it's case reference
     And I load the stage 2 complaints case by selecting its case reference from the Escalate Case column
     Then the case should be loaded
+
+
+#  SMC workflow cancelled. Steps and code might be useful for future work implementing PSU specific sub-workflow into other complaints workflows
+
+#     SMC COMPLAINTS
+
+  @SMCComplaints
+  Scenario Outline: User tests SMC complaint case search criteria
+    Given I am logged into "CS" as user "SMC_USER"
+    When I navigate to the "Search" page
+    And I enter "<infoValue>" into the "<infoType>" search field in the "SMC" search configuration
+    And I click the search button on the search page
+    Then I check that the search results have the correct "<infoType>"
+    Examples:
+      | infoType                          | infoValue                             |
+      | Correspondent full name           | Sam McTester                          |
+      | Correspondent postcode            | AB1 2CD                               |
+      | Correspondent email address       | SamMcTester@Test.com                  |
+      | Complainant date of birth         | 01/01/2001                            |
+      | Complainant Home Office Reference | Test entry for Home Office Reference  |
+      | PSU Reference                     | 123456789                             |
+
+  @SMCComplaints
+  Scenario: User can search for a SMC complaint case by its case reference
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a single "SMC" case
+    And I search for the case by its case reference
+    Then the created case should be the only case visible in the search results

--- a/src/test/resources/features/complaints/ComplaintsTriageAndInvestigation.feature
+++ b/src/test/resources/features/complaints/ComplaintsTriageAndInvestigation.feature
@@ -302,7 +302,7 @@ Feature: Complaints Triage
 
 #     IEDET COMPLAINTS
 
-  @ComplaintsWorkflow @IEDETAndSMCRegression @IEDETComplaints
+  @ComplaintsWorkflow @IEDETRegression @IEDETComplaints
   Scenario Outline: User completes the Triage stage for an IEDET complaint case
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to the "Triage" stage
@@ -323,50 +323,12 @@ Feature: Complaints Triage
       | DEPMU                       |
 
   # Expected failure. Defect HOCS-5635 raised.
-  @IEDETAndSMCRegression @IEDETComplaints
+  @IEDETRegression @IEDETComplaints
   Scenario: User can transfer a IEDET complaints case to CCH
     Given I am logged into "CS" as user "IEDET_USER"
     When I create a "IEDET" case and move it to the "Triage" stage
     And I load and claim the current case
     And I select the "Send to CCH" action for an IEDET case at the Triage stage
-    Then the case should be closed
-
-
-#     SMC COMPLAINTS
-
-  @ComplaintsWorkflow @IEDETAndSMCRegression @SMCComplaints
-  Scenario: User completes the Triage stage for an SMC complaint case
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Triage" stage
-    And I load and claim the current case
-    And I accept the case at Triage stage
-    And I enter details on PSU Reference page
-    And I accept the previous Claim Category selection
-    And I accept the previous Case Details selection
-    And I submit details on the Triage Capture Reason page
-    And I send the case to drafting
-    And I load the current case
-    And the summary should display the owning team as "Serious Misconduct"
-    And the read-only Case Details accordion should contain all case information entered during the "Triage" stage
-
-  # Expected failure. Defect HOCS-3980 raised.
-  @ComplaintsWorkflow @IEDETAndSMCRegression @SMCComplaints
-  Scenario: User can transfer a SMC complaint case to a UKVI complaint case at Triage stage
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Triage" stage
-    And I load and claim the current case
-    And I select to Transfer the complaint
-    And I enter a reason for "CCH" transfer and continue
-    Then the case should be closed
-
-  # Expected failure. Defect HOCS-3980 raised.
-  @ComplaintsWorkflow @IEDETAndSMCRegression @SMCComplaints
-  Scenario: User can transfer a SMC complaint case to an IEDET complaint case at Triage stage
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create a "SMC" case and move it to the "Triage" stage
-    And I load and claim the current case
-    And I select to Transfer the complaint
-    And I enter a reason for "IE Detention" transfer and continue
     Then the case should be closed
 
 
@@ -717,3 +679,43 @@ Feature: Complaints Triage
       | Complainant      | Cancel   | Cancelled |
       | Business         | Complete | Complete  |
       | Business         | Cancel   | Cancelled |
+
+
+#  SMC workflow cancelled. Steps and code might be useful for future work implementing PSU specific sub-workflow into other complaints workflows
+
+#     SMC COMPLAINTS
+
+  @ComplaintsWorkflow @SMCComplaints
+  Scenario: User completes the Triage stage for an SMC complaint case
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Triage" stage
+    And I load and claim the current case
+    And I accept the case at Triage stage
+    And I enter details on PSU Reference page
+    And I accept the previous Claim Category selection
+    And I accept the previous Case Details selection
+    And I submit details on the Triage Capture Reason page
+    And I send the case to drafting
+    And I load the current case
+    And the summary should display the owning team as "Serious Misconduct"
+    And the read-only Case Details accordion should contain all case information entered during the "Triage" stage
+
+  # Expected failure. Defect HOCS-3980 raised.
+  @ComplaintsWorkflow @SMCComplaints
+  Scenario: User can transfer a SMC complaint case to a UKVI complaint case at Triage stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Triage" stage
+    And I load and claim the current case
+    And I select to Transfer the complaint
+    And I enter a reason for "CCH" transfer and continue
+    Then the case should be closed
+
+  # Expected failure. Defect HOCS-3980 raised.
+  @ComplaintsWorkflow @SMCComplaints
+  Scenario: User can transfer a SMC complaint case to an IEDET complaint case at Triage stage
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create a "SMC" case and move it to the "Triage" stage
+    And I load and claim the current case
+    And I select to Transfer the complaint
+    And I enter a reason for "IE Detention" transfer and continue
+    Then the case should be closed

--- a/src/test/resources/features/complaints/ComplaintsWorkstacks.feature
+++ b/src/test/resources/features/complaints/ComplaintsWorkstacks.feature
@@ -51,46 +51,11 @@ Feature: Complaints Workstacks
 
 #     IEDET COMPLAINTS
 
-  @IEDETAndSMCRegression @IEDETComplaints
+  @IEDETRegression @IEDETComplaints
   Scenario: IEDET complaints user sees the required information when viewing a workstack
     Given I am logged into "CS" as user "IEDET_USER"
     And I enter the "IE Detention" workstack
     Then the "IE Detention" workstack should contain only the expected columns
-
-
-#     SMC COMPLAINTS
-
-  @IEDETAndSMCRegression @IEDETComplaints
-  Scenario Outline: Serious Misconduct complaints user sees the required information when viewing a workstack
-    Given I am logged into "CS" as user "SMC_USER"
-    And I enter the "<workstack>" workstack
-    Then the "<workstack>" workstack should contain only the expected columns
-    Examples:
-      | workstack                   |
-      | Serious Misconduct          |
-      | Serious Misconduct My Cases |
-
-  @IEDETAndSMCRegression
-  Scenario Outline: SMC User is able to see the deadline of a case close to its deadline highlighted in yellow
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create an SMC case received <amountOfDays> workdays in the past and move it to the "<stage>" stage
-    And I click to view the case in the "<workstack>" workstack
-    Then the case deadline should be highlighted "yellow"
-    Examples:
-      | amountOfDays | stage        | workstack          |
-      | 55           | Registration | SMC Registration   |
-      | 55           | Triage       | Serious Misconduct |
-
-  @IEDETAndSMCRegression
-  Scenario Outline: SMC User is able to see an overdue case deadline highlighted in red
-    Given I am logged into "CS" as user "SMC_USER"
-    When I create an SMC case received <amountOfDays> workdays in the past and move it to the "<stage>" stage
-    And I click to view the case in the "<workstack>" workstack
-    Then the case deadline should be highlighted "red"
-    Examples:
-      | amountOfDays | stage        | workstack          |
-      | 61           | Registration | SMC Registration   |
-      | 61           | Triage       | Serious Misconduct |
 
 
 #     BF COMPLAINTS
@@ -166,3 +131,40 @@ Feature: Complaints Workstacks
       | BF2      | BF_USER    | 21           | Border Force Complaints (Stage 2) |
       | POGR     | POGR_USER  | 11           | HMPO/GRO Registration             |
       | POGR2    | POGR_USER  | 11           | HMPO/GRO Registration (Stage 2)   |
+
+
+#  SMC workflow cancelled. Steps and code might be useful for future work implementing PSU specific sub-workflow into other complaints workflows
+
+#     SMC COMPLAINTS
+
+  @SMCComplaints
+  Scenario Outline: Serious Misconduct complaints user sees the required information when viewing a workstack
+    Given I am logged into "CS" as user "SMC_USER"
+    And I enter the "<workstack>" workstack
+    Then the "<workstack>" workstack should contain only the expected columns
+    Examples:
+      | workstack                   |
+      | Serious Misconduct          |
+      | Serious Misconduct My Cases |
+
+  @SMCComplaints
+  Scenario Outline: SMC User is able to see the deadline of a case close to its deadline highlighted in yellow
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create an SMC case received <amountOfDays> workdays in the past and move it to the "<stage>" stage
+    And I click to view the case in the "<workstack>" workstack
+    Then the case deadline should be highlighted "yellow"
+    Examples:
+      | amountOfDays | stage        | workstack          |
+      | 55           | Registration | SMC Registration   |
+      | 55           | Triage       | Serious Misconduct |
+
+  @SMCComplaints
+  Scenario Outline: SMC User is able to see an overdue case deadline highlighted in red
+    Given I am logged into "CS" as user "SMC_USER"
+    When I create an SMC case received <amountOfDays> workdays in the past and move it to the "<stage>" stage
+    And I click to view the case in the "<workstack>" workstack
+    Then the case deadline should be highlighted "red"
+    Examples:
+      | amountOfDays | stage        | workstack          |
+      | 61           | Registration | SMC Registration   |
+      | 61           | Triage       | Serious Misconduct |

--- a/src/test/resources/features/complaints/SMCPermissions.feature
+++ b/src/test/resources/features/complaints/SMCPermissions.feature
@@ -1,7 +1,10 @@
+
+#  SMC workflow cancelled. Steps and code might be useful for future work implementing PSU specific sub-workflow into other complaints workflows
+
 @SMCPermissions @Complaints
 Feature: SMC Permissions
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Registration user, when viewing a case, I should only see non-sensitive case data
     Given I am logged into "CS" as user "SMC_USER"
     And I create a "SMC" case and move it to the "CASE CLOSED" stage
@@ -10,7 +13,7 @@ Feature: SMC Permissions
     Then I can only view sections of the Case Details accordion that contain non-sensitive case data
     And I can only see non-sensitive information in the Summary tab
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Registration user, when viewing a case that has passed Registration, I should not be able to see any allocation information
     Given I am logged into "CS" as user "SMC_USER"
     And I create a "SMC" case and move it to the "Triage" stage
@@ -20,7 +23,7 @@ Feature: SMC Permissions
     And I should not be able to see which team the case is currently assigned to
     And I should not be able to see which user is currently assigned to the case
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Casework user, when viewing a case, I should be able to see all case data
     Given I am logged into "CS" as user "SMC_USER"
     And I create a "SMC" case and move it to the "CASE CLOSED" stage, recording all case data
@@ -29,7 +32,7 @@ Feature: SMC Permissions
     Then all case data should be visible in the read-only Case Details accordion
     And I can see all of the cases Summary data
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Registration user, when I view a case, I should only be able to see documents that I uploaded to the case
     Given I am logged into "CS" as user "SMC_REGISTRATION_USER_1"
     And I manage the documents of a new "SMC" case
@@ -39,7 +42,7 @@ Feature: SMC Permissions
     Then I should not be able to see the document uploaded by the previous user
     And I should be able to see the document uploaded by the current user
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Casework user, when I view a case, I should be able to see all documents that have been uploaded to the case
     Given I am logged into "CS" as user "SMC_REGISTRATION_USER_1"
     And I manage the documents of a new "SMC" case
@@ -49,7 +52,7 @@ Feature: SMC Permissions
     Then I should be able to see the document uploaded by the previous user
     And I should be able to see the document uploaded by the current user
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Registration user, when I view a case, I should only be able to see case notes that I added to the timeline
     Given I am logged into "CS" as user "SMC_REGISTRATION_USER_1"
     And I create a single "SMC" case
@@ -61,7 +64,7 @@ Feature: SMC Permissions
     Then I should not be able to see the case note added by the previous user
     And I should be able to see the case note added by the current user
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Casework user, when I view a case, I should be able to see all case notes that have been added to the timeline
     Given I am logged into "CS" as user "SMC_REGISTRATION_USER_1"
     And I create a single "SMC" case
@@ -73,7 +76,7 @@ Feature: SMC Permissions
     Then I should be able to see the case note added by the previous user
     And I should be able to see the case note added by the current user
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Registration user, when I view a cases timeline, I should only be able to see logs for case actions I took
     Given I am logged into "CS" as user "SMC_USER"
     And I create a single "SMC" case
@@ -84,7 +87,7 @@ Feature: SMC Permissions
     Then I should be able to see logs for case actions taken by the current user
     And I should not be able to see logs for case actions taken by the previous user
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Casework user, when I view a cases timeline, I should only be able to see all of the logs
     Given I am logged into "CS" as user "SMC_REGISTRATION_USER_1"
     And I create a "SMC" case and move it to the "Triage" stage
@@ -95,7 +98,7 @@ Feature: SMC Permissions
     Then I should be able to see logs for case actions taken by the current user
     And I should be able to see logs for case actions taken by the previous user
 
-  @IEDETAndSMCRegression @SMCComplaints
+  @SMCComplaints
   Scenario: As a SMC Registration user, I should not be able to complete any actions against a case
     Given I am logged into "CS" as user "SMC_REGISTRATION_USER_1"
     And I get a new "SMC" case

--- a/src/test/resources/features/cs/CreateCase.feature
+++ b/src/test/resources/features/cs/CreateCase.feature
@@ -20,7 +20,6 @@ Feature: Create case
       | COMP     | Registration                | To document             | Complaint Registration            |
       | COMP2    | Stage 2 Registration        | To document             | Stage 2 Complaint Registration    |
       | IEDET    | Registration                | To document             | IE Detention                      |
-      | SMC      | Registration                | To document             | SMC Registration                  |
       | FOI      | Case Creation               | Request                 | FOI Creation                      |
       | TO       | Data Input                  | Initial Correspondence  | Treat Official Creation           |
       | BF       | Case Registration           | To document             | Border Force Complaints           |

--- a/src/test/resources/features/cs/Deadlines.feature
+++ b/src/test/resources/features/cs/Deadlines.feature
@@ -33,7 +33,6 @@ Feature: Deadlines
       | COMP     |
       | COMP2    |
       | IEDET    |
-      | SMC      |
       | FOI      |
       | TO       |
       | BF       |

--- a/src/test/resources/features/cs/ManageDocuments.feature
+++ b/src/test/resources/features/cs/ManageDocuments.feature
@@ -41,7 +41,6 @@ Feature: Manage Documents
       | COMP     |
       | COMP2    |
       | IEDET    |
-      | SMC      |
       | BF       |
       | BF2      |
       | TO       |


### PR DESCRIPTION
Removed regression tags from SMC scenarios.
Renamed regression pipeline to not reference SMC.
Moved all SMC scenarios to bottom of each page and added note that the workflow is cancelled. Deleted SMC from CS Platform level scenarios.
Deleted SMC from random case creation methods. Added in missed stage 2 complaint types.