### PR TITLE
BusinessArea wording changes to match env, added test logic for new wording

### DIFF
--- a/src/test/java/com/hocs/test/pages/decs/SummaryTab.java
+++ b/src/test/java/com/hocs/test/pages/decs/SummaryTab.java
@@ -405,6 +405,10 @@ public class SummaryTab extends BasePage {
         }
         String businessArea = sessionVariableCalled("businessArea");
         String refType = sessionVariableCalled("refType");
+
+        if (businessArea.equalsIgnoreCase("Coronavirus (COVID-19)")){
+            businessArea = "Coronavirus";
+        }
         assertThat(activeTeam.contains(businessArea) && activeTeam.contains(refType), is(true));
     }
 

--- a/src/test/resources/features/mpam/Creation.feature
+++ b/src/test/resources/features/mpam/Creation.feature
@@ -79,20 +79,20 @@ Feature: Creation
     Then the case should be moved to the "Triage" stage
     Examples:
       | businessArea | refType     |
-      | UKVI         | Ministerial |
-      | BF           | Ministerial |
-      | IE           | Ministerial |
-      | EUSS         | Ministerial |
-      | HMPO         | Ministerial |
-      | Windrush     | Ministerial |
-      | Coronavirus  | Ministerial |
-      | UKVI         | Official    |
-      | BF           | Official    |
-      | IE           | Official    |
-      | EUSS         | Official    |
-      | HMPO         | Official    |
-      | Windrush     | Official    |
-      | Coronavirus  | Official    |
+      | UKVI                   | Ministerial |
+      | BF                     | Ministerial |
+      | IE                     | Ministerial |
+      | EUSS                   | Ministerial |
+      | HMPO                   | Ministerial |
+      | Windrush               | Ministerial |
+      | Coronavirus (COVID-19) | Ministerial |
+      | UKVI                   | Official    |
+      | BF                     | Official    |
+      | IE                     | Official    |
+      | EUSS                   | Official    |
+      | HMPO                   | Official    |
+      | Windrush               | Official    |
+      | Coronavirus (COVID-19) | Official    |
 
   @Validation
   Scenario: User attempts to progress a case without adding an MP correspondent

--- a/src/test/resources/features/mpam/MPAMCaseDetailsAccordion.feature
+++ b/src/test/resources/features/mpam/MPAMCaseDetailsAccordion.feature
@@ -50,13 +50,13 @@ Feature: MPAM Case Details Accordion
     And I change the business area of the case to "<businessArea>"
     Then the case should have changed to the "<businessArea>" business area
     Examples:
-      | businessArea |
-      | BF           |
-      | IE           |
-      | EUSS         |
-      | HMPO         |
-      | Windrush     |
-      | Coronavirus  |
+      | businessArea           |
+      | BF                     |
+      | IE                     |
+      | EUSS                   |
+      | HMPO                   |
+      | Windrush               |
+      | Coronavirus (COVID-19) |
 
 
   Scenario Outline: User checks that the change business area hypertext is displayed at the correct stages

--- a/src/test/resources/features/mpam/TeamRouting/Campaigns.feature
+++ b/src/test/resources/features/mpam/TeamRouting/Campaigns.feature
@@ -12,21 +12,21 @@ Feature: Campaigns
     Then the case should be moved to the "Campaign" stage
     And the case should be in the correct MPAM "Campaign" team workstack
     Examples:
-      | businessArea | refType       | stage  |
-      | UKVI         | Ministerial   | Triage |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official      | Triage |
-      | BF           | Official      | Triage |
-      | IE           | Official      | Triage |
-      | EUSS         | Official      | Triage |
-      | HMPO         | Official      | Triage |
-      | Windrush     | Official      | Triage |
-      | Coronavirus  | Official      | Triage |
+      | businessArea           | refType     | stage  |
+#      | UKVI                   | Ministerial | Triage |
+#      | BF                     | Ministerial | Triage |
+#      | IE                     | Ministerial | Triage |
+#      | EUSS                   | Ministerial | Triage |
+#      | HMPO                   | Ministerial | Triage |
+#      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+#      | UKVI                   | Official    | Triage |
+#      | BF                     | Official    | Triage |
+#      | IE                     | Official    | Triage |
+#      | EUSS                   | Official    | Triage |
+#      | HMPO                   | Official    | Triage |
+#      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User moves a case with specific Business Area and Reference Type to Campaign from Triage (On Hold)
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<initial>" stage
@@ -38,21 +38,21 @@ Feature: Campaigns
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType       | initial | stage    |
-      | UKVI         | Ministerial   | Triage  | Campaign |
-      | BF           | Ministerial   | Triage  | Campaign |
-      | IE           | Ministerial   | Triage  | Campaign |
-      | EUSS         | Ministerial   | Triage  | Campaign |
-      | HMPO         | Ministerial   | Triage  | Campaign |
-      | Windrush     | Ministerial   | Triage  | Campaign |
-      | Coronavirus  | Ministerial   | Triage  | Campaign |
-      | UKVI         | Official      | Triage  | Campaign |
-      | BF           | Official      | Triage  | Campaign |
-      | IE           | Official      | Triage  | Campaign |
-      | EUSS         | Official      | Triage  | Campaign |
-      | HMPO         | Official      | Triage  | Campaign |
-      | Windrush     | Official      | Triage  | Campaign |
-      | Coronavirus  | Official      | Triage  | Campaign |
+      | businessArea           | refType     | initial | stage    |
+      | UKVI                   | Ministerial | Triage  | Campaign |
+      | BF                     | Ministerial | Triage  | Campaign |
+      | IE                     | Ministerial | Triage  | Campaign |
+      | EUSS                   | Ministerial | Triage  | Campaign |
+      | HMPO                   | Ministerial | Triage  | Campaign |
+      | Windrush               | Ministerial | Triage  | Campaign |
+      | Coronavirus (COVID-19) | Ministerial | Triage  | Campaign |
+      | UKVI                   | Official    | Triage  | Campaign |
+      | BF                     | Official    | Triage  | Campaign |
+      | IE                     | Official    | Triage  | Campaign |
+      | EUSS                   | Official    | Triage  | Campaign |
+      | HMPO                   | Official    | Triage  | Campaign |
+      | Windrush               | Official    | Triage  | Campaign |
+      | Coronavirus (COVID-19) | Official    | Triage  | Campaign |
 
   Scenario Outline: User moves a case with specific Business Area and Reference Type to Campaign from Triage (Escalated)
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<initial>" stage
@@ -64,21 +64,21 @@ Feature: Campaigns
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType       | initial | stage    |
-      | UKVI         | Ministerial   | Triage  | Campaign |
-      | BF           | Ministerial   | Triage  | Campaign |
-      | IE           | Ministerial   | Triage  | Campaign |
-      | EUSS         | Ministerial   | Triage  | Campaign |
-      | HMPO         | Ministerial   | Triage  | Campaign |
-      | Windrush     | Ministerial   | Triage  | Campaign |
-      | Coronavirus  | Ministerial   | Triage  | Campaign |
-      | UKVI         | Official      | Triage  | Campaign |
-      | BF           | Official      | Triage  | Campaign |
-      | IE           | Official      | Triage  | Campaign |
-      | EUSS         | Official      | Triage  | Campaign |
-      | HMPO         | Official      | Triage  | Campaign |
-      | Windrush     | Official      | Triage  | Campaign |
-      | Coronavirus  | Official      | Triage  | Campaign |
+      | businessArea           | refType     | initial | stage    |
+      | UKVI                   | Ministerial | Triage  | Campaign |
+      | BF                     | Ministerial | Triage  | Campaign |
+      | IE                     | Ministerial | Triage  | Campaign |
+      | EUSS                   | Ministerial | Triage  | Campaign |
+      | HMPO                   | Ministerial | Triage  | Campaign |
+      | Windrush               | Ministerial | Triage  | Campaign |
+      | Coronavirus (COVID-19) | Ministerial | Triage  | Campaign |
+      | UKVI                   | Official    | Triage  | Campaign |
+      | BF                     | Official    | Triage  | Campaign |
+      | IE                     | Official    | Triage  | Campaign |
+      | EUSS                   | Official    | Triage  | Campaign |
+      | HMPO                   | Official    | Triage  | Campaign |
+      | Windrush               | Official    | Triage  | Campaign |
+      | Coronavirus (COVID-19) | Official    | Triage  | Campaign |
 
   Scenario Outline: User moves a case with specific Business Area and Reference Type to Campaign from Triage (Contribution Requested)
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<initial>" stage
@@ -90,21 +90,21 @@ Feature: Campaigns
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType       | initial | stage    |
-      | UKVI         | Ministerial   | Triage  | Campaign |
-      | BF           | Ministerial   | Triage  | Campaign |
-      | IE           | Ministerial   | Triage  | Campaign |
-      | EUSS         | Ministerial   | Triage  | Campaign |
-      | HMPO         | Ministerial   | Triage  | Campaign |
-      | Windrush     | Ministerial   | Triage  | Campaign |
-      | Coronavirus  | Ministerial   | Triage  | Campaign |
-      | UKVI         | Official      | Triage  | Campaign |
-      | BF           | Official      | Triage  | Campaign |
-      | IE           | Official      | Triage  | Campaign |
-      | EUSS         | Official      | Triage  | Campaign |
-      | HMPO         | Official      | Triage  | Campaign |
-      | Windrush     | Official      | Triage  | Campaign |
-      | Coronavirus  | Official      | Triage  | Campaign |
+      | businessArea           | refType     | initial | stage    |
+      | UKVI                   | Ministerial | Triage  | Campaign |
+      | BF                     | Ministerial | Triage  | Campaign |
+      | IE                     | Ministerial | Triage  | Campaign |
+      | EUSS                   | Ministerial | Triage  | Campaign |
+      | HMPO                   | Ministerial | Triage  | Campaign |
+      | Windrush               | Ministerial | Triage  | Campaign |
+      | Coronavirus (COVID-19) | Ministerial | Triage  | Campaign |
+      | UKVI                   | Official    | Triage  | Campaign |
+      | BF                     | Official    | Triage  | Campaign |
+      | IE                     | Official    | Triage  | Campaign |
+      | EUSS                   | Official    | Triage  | Campaign |
+      | HMPO                   | Official    | Triage  | Campaign |
+      | Windrush               | Official    | Triage  | Campaign |
+      | Coronavirus (COVID-19) | Official    | Triage  | Campaign |
 
   Scenario Outline: User moves a case with a specific Business Area and Reference Type from Draft to Campaign and its appropriate team
     When I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -114,21 +114,21 @@ Feature: Campaigns
     Then the case should be moved to the "Campaign" stage
     And the case should be in the correct MPAM "Campaign" team workstack
     Examples:
-      | businessArea | refType       | stage |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official      | Draft |
-      | BF           | Official      | Draft |
-      | IE           | Official      | Draft |
-      | EUSS         | Official      | Draft |
-      | HMPO         | Official      | Draft |
-      | Windrush     | Official      | Draft |
-      | Coronavirus  | Official      | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |
 
   Scenario Outline: User moves a case with specific Business Area and Reference Type to Campaign from Draft (On Hold)
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<initial>" stage
@@ -140,21 +140,21 @@ Feature: Campaigns
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType       | initial | stage    |
-      | UKVI         | Ministerial   | Draft   | Campaign |
-      | BF           | Ministerial   | Draft   | Campaign |
-      | IE           | Ministerial   | Draft   | Campaign |
-      | EUSS         | Ministerial   | Draft   | Campaign |
-      | HMPO         | Ministerial   | Draft   | Campaign |
-      | Windrush     | Ministerial   | Draft   | Campaign |
-      | Coronavirus  | Ministerial   | Draft   | Campaign |
-      | UKVI         | Official      | Draft   | Campaign |
-      | BF           | Official      | Draft   | Campaign |
-      | IE           | Official      | Draft   | Campaign |
-      | EUSS         | Official      | Draft   | Campaign |
-      | HMPO         | Official      | Draft   | Campaign |
-      | Windrush     | Official      | Draft   | Campaign |
-      | Coronavirus  | Official      | Draft   | Campaign |
+      | businessArea           | refType     | initial | stage    |
+      | UKVI                   | Ministerial | Draft   | Campaign |
+      | BF                     | Ministerial | Draft   | Campaign |
+      | IE                     | Ministerial | Draft   | Campaign |
+      | EUSS                   | Ministerial | Draft   | Campaign |
+      | HMPO                   | Ministerial | Draft   | Campaign |
+      | Windrush               | Ministerial | Draft   | Campaign |
+      | Coronavirus (COVID-19) | Ministerial | Draft   | Campaign |
+      | UKVI                   | Official    | Draft   | Campaign |
+      | BF                     | Official    | Draft   | Campaign |
+      | IE                     | Official    | Draft   | Campaign |
+      | EUSS                   | Official    | Draft   | Campaign |
+      | HMPO                   | Official    | Draft   | Campaign |
+      | Windrush               | Official    | Draft   | Campaign |
+      | Coronavirus (COVID-19) | Official    | Draft   | Campaign |
 
   Scenario Outline: User moves a case with specific Business Area and Reference Type to Campaign from Draft (Escalated)
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<initial>" stage
@@ -166,21 +166,21 @@ Feature: Campaigns
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType       | initial | stage    |
-      | UKVI         | Ministerial   | Draft   | Campaign |
-      | BF           | Ministerial   | Draft   | Campaign |
-      | IE           | Ministerial   | Draft   | Campaign |
-      | EUSS         | Ministerial   | Draft   | Campaign |
-      | HMPO         | Ministerial   | Draft   | Campaign |
-      | Windrush     | Ministerial   | Draft   | Campaign |
-      | Coronavirus  | Ministerial   | Draft   | Campaign |
-      | UKVI         | Official      | Draft   | Campaign |
-      | BF           | Official      | Draft   | Campaign |
-      | IE           | Official      | Draft   | Campaign |
-      | EUSS         | Official      | Draft   | Campaign |
-      | HMPO         | Official      | Draft   | Campaign |
-      | Windrush     | Official      | Draft   | Campaign |
-      | Coronavirus  | Official      | Draft   | Campaign |
+      | businessArea           | refType     | initial | stage    |
+      | UKVI                   | Ministerial | Draft   | Campaign |
+      | BF                     | Ministerial | Draft   | Campaign |
+      | IE                     | Ministerial | Draft   | Campaign |
+      | EUSS                   | Ministerial | Draft   | Campaign |
+      | HMPO                   | Ministerial | Draft   | Campaign |
+      | Windrush               | Ministerial | Draft   | Campaign |
+      | Coronavirus (COVID-19) | Ministerial | Draft   | Campaign |
+      | UKVI                   | Official    | Draft   | Campaign |
+      | BF                     | Official    | Draft   | Campaign |
+      | IE                     | Official    | Draft   | Campaign |
+      | EUSS                   | Official    | Draft   | Campaign |
+      | HMPO                   | Official    | Draft   | Campaign |
+      | Windrush               | Official    | Draft   | Campaign |
+      | Coronavirus (COVID-19) | Official    | Draft   | Campaign |
 
   Scenario Outline: User moves a case with specific Business Area and Reference Type to Campaign from Draft (Contributions Requested)
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<initial>" stage
@@ -192,21 +192,21 @@ Feature: Campaigns
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType       | initial | stage    |
-      | UKVI         | Ministerial   | Draft   | Campaign |
-      | BF           | Ministerial   | Draft   | Campaign |
-      | IE           | Ministerial   | Draft   | Campaign |
-      | EUSS         | Ministerial   | Draft   | Campaign |
-      | HMPO         | Ministerial   | Draft   | Campaign |
-      | Windrush     | Ministerial   | Draft   | Campaign |
-      | Coronavirus  | Ministerial   | Draft   | Campaign |
-      | UKVI         | Official      | Draft   | Campaign |
-      | BF           | Official      | Draft   | Campaign |
-      | IE           | Official      | Draft   | Campaign |
-      | EUSS         | Official      | Draft   | Campaign |
-      | HMPO         | Official      | Draft   | Campaign |
-      | Windrush     | Official      | Draft   | Campaign |
-      | Coronavirus  | Official      | Draft   | Campaign |
+      | businessArea           | refType     | initial | stage    |
+      | UKVI                   | Ministerial | Draft   | Campaign |
+      | BF                     | Ministerial | Draft   | Campaign |
+      | IE                     | Ministerial | Draft   | Campaign |
+      | EUSS                   | Ministerial | Draft   | Campaign |
+      | HMPO                   | Ministerial | Draft   | Campaign |
+      | Windrush               | Ministerial | Draft   | Campaign |
+      | Coronavirus (COVID-19) | Ministerial | Draft   | Campaign |
+      | UKVI                   | Official    | Draft   | Campaign |
+      | BF                     | Official    | Draft   | Campaign |
+      | IE                     | Official    | Draft   | Campaign |
+      | EUSS                   | Official    | Draft   | Campaign |
+      | HMPO                   | Official    | Draft   | Campaign |
+      | Windrush               | Official    | Draft   | Campaign |
+      | Coronavirus (COVID-19) | Official    | Draft   | Campaign |
 
   Scenario Outline: User moves a case with a specific Business Area and Reference Type from QA to Campaign and its appropriate team
     When I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -216,21 +216,21 @@ Feature: Campaigns
     Then the case should be moved to the "Campaign" stage
     And the case should be in the correct MPAM "Campaign" team workstack
     Examples:
-      | businessArea | refType       | stage |
-      | UKVI         | Ministerial   | QA    |
-      | BF           | Ministerial   | QA    |
-      | IE           | Ministerial   | QA    |
-      | EUSS         | Ministerial   | QA    |
-      | HMPO         | Ministerial   | QA    |
-      | Windrush     | Ministerial   | QA    |
-      | Coronavirus  | Ministerial   | QA    |
-      | UKVI         | Official      | QA    |
-      | BF           | Official      | QA    |
-      | IE           | Official      | QA    |
-      | EUSS         | Official      | QA    |
-      | HMPO         | Official      | QA    |
-      | Windrush     | Official      | QA    |
-      | Coronavirus  | Official      | QA    |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | QA    |
+      | BF                     | Ministerial | QA    |
+      | IE                     | Ministerial | QA    |
+      | EUSS                   | Ministerial | QA    |
+      | HMPO                   | Ministerial | QA    |
+      | Windrush               | Ministerial | QA    |
+      | Coronavirus (COVID-19) | Ministerial | QA    |
+      | UKVI                   | Official    | QA    |
+      | BF                     | Official    | QA    |
+      | IE                     | Official    | QA    |
+      | EUSS                   | Official    | QA    |
+      | HMPO                   | Official    | QA    |
+      | Windrush               | Official    | QA    |
+      | Coronavirus (COVID-19) | Official    | QA    |
 
   Scenario Outline: User moves a case with specific Business Area and Reference Type to Campaign from QA (On Hold)
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<initial>" stage
@@ -242,21 +242,21 @@ Feature: Campaigns
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType       | initial | stage    |
-      | UKVI         | Ministerial   | QA      | Campaign |
-      | BF           | Ministerial   | QA      | Campaign |
-      | IE           | Ministerial   | QA      | Campaign |
-      | EUSS         | Ministerial   | QA      | Campaign |
-      | HMPO         | Ministerial   | QA      | Campaign |
-      | Windrush     | Ministerial   | QA      | Campaign |
-      | Coronavirus  | Ministerial   | QA      | Campaign |
-      | UKVI         | Official      | QA      | Campaign |
-      | BF           | Official      | QA      | Campaign |
-      | IE           | Official      | QA      | Campaign |
-      | EUSS         | Official      | QA      | Campaign |
-      | HMPO         | Official      | QA      | Campaign |
-      | Windrush     | Official      | QA      | Campaign |
-      | Coronavirus  | Official      | QA      | Campaign |
+      | businessArea           | refType     | initial | stage    |
+      | UKVI                   | Ministerial | QA      | Campaign |
+      | BF                     | Ministerial | QA      | Campaign |
+      | IE                     | Ministerial | QA      | Campaign |
+      | EUSS                   | Ministerial | QA      | Campaign |
+      | HMPO                   | Ministerial | QA      | Campaign |
+      | Windrush               | Ministerial | QA      | Campaign |
+      | Coronavirus (COVID-19) | Ministerial | QA      | Campaign |
+      | UKVI                   | Official    | QA      | Campaign |
+      | BF                     | Official    | QA      | Campaign |
+      | IE                     | Official    | QA      | Campaign |
+      | EUSS                   | Official    | QA      | Campaign |
+      | HMPO                   | Official    | QA      | Campaign |
+      | Windrush               | Official    | QA      | Campaign |
+      | Coronavirus (COVID-19) | Official    | QA      | Campaign |
 
   Scenario Outline: User moves a case with specific Business Area and Reference Type to Campaign from QA (Escalated)
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<initial>" stage
@@ -268,21 +268,21 @@ Feature: Campaigns
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType       | initial | stage    |
-      | UKVI         | Ministerial   | QA      | Campaign |
-      | BF           | Ministerial   | QA      | Campaign |
-      | IE           | Ministerial   | QA      | Campaign |
-      | EUSS         | Ministerial   | QA      | Campaign |
-      | HMPO         | Ministerial   | QA      | Campaign |
-      | Windrush     | Ministerial   | QA      | Campaign |
-      | Coronavirus  | Ministerial   | QA      | Campaign |
-      | UKVI         | Official      | QA      | Campaign |
-      | BF           | Official      | QA      | Campaign |
-      | IE           | Official      | QA      | Campaign |
-      | EUSS         | Official      | QA      | Campaign |
-      | HMPO         | Official      | QA      | Campaign |
-      | Windrush     | Official      | QA      | Campaign |
-      | Coronavirus  | Official      | QA      | Campaign |
+      | businessArea           | refType     | initial | stage    |
+      | UKVI                   | Ministerial | QA      | Campaign |
+      | BF                     | Ministerial | QA      | Campaign |
+      | IE                     | Ministerial | QA      | Campaign |
+      | EUSS                   | Ministerial | QA      | Campaign |
+      | HMPO                   | Ministerial | QA      | Campaign |
+      | Windrush               | Ministerial | QA      | Campaign |
+      | Coronavirus (COVID-19) | Ministerial | QA      | Campaign |
+      | UKVI                   | Official    | QA      | Campaign |
+      | BF                     | Official    | QA      | Campaign |
+      | IE                     | Official    | QA      | Campaign |
+      | EUSS                   | Official    | QA      | Campaign |
+      | HMPO                   | Official    | QA      | Campaign |
+      | Windrush               | Official    | QA      | Campaign |
+      | Coronavirus (COVID-19) | Official    | QA      | Campaign |
 
   Scenario Outline: User moves a case with a specific Business Area and Reference Type from Dispatch stages to Campaign and its appropriate team
     When I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -292,21 +292,21 @@ Feature: Campaigns
     Then the case should be moved to the "Campaign" stage
     And the case should be in the correct MPAM "Campaign" team workstack
     Examples:
-      | businessArea | refType       | stage             |
-      | UKVI         | Ministerial   | Private Office    |
-      | BF           | Ministerial   | Private Office    |
-      | IE           | Ministerial   | Private Office    |
-      | EUSS         | Ministerial   | Private Office    |
-      | HMPO         | Ministerial   | Private Office    |
-      | Windrush     | Ministerial   | Private Office    |
-      | Coronavirus  | Ministerial   | Private Office    |
-      | UKVI         | Official      | Awaiting Dispatch |
-      | BF           | Official      | Awaiting Dispatch |
-      | IE           | Official      | Awaiting Dispatch |
-      | EUSS         | Official      | Awaiting Dispatch |
-      | HMPO         | Official      | Awaiting Dispatch |
-      | Windrush     | Official      | Awaiting Dispatch |
-      | Coronavirus  | Official      | Awaiting Dispatch |
+      | businessArea           | refType     | stage             |
+      | UKVI                   | Ministerial | Private Office    |
+      | BF                     | Ministerial | Private Office    |
+      | IE                     | Ministerial | Private Office    |
+      | EUSS                   | Ministerial | Private Office    |
+      | HMPO                   | Ministerial | Private Office    |
+      | Windrush               | Ministerial | Private Office    |
+      | Coronavirus (COVID-19) | Ministerial | Private Office    |
+      | UKVI                   | Official    | Awaiting Dispatch |
+      | BF                     | Official    | Awaiting Dispatch |
+      | IE                     | Official    | Awaiting Dispatch |
+      | EUSS                   | Official    | Awaiting Dispatch |
+      | HMPO                   | Official    | Awaiting Dispatch |
+      | Windrush               | Official    | Awaiting Dispatch |
+      | Coronavirus (COVID-19) | Official    | Awaiting Dispatch |
 
   Scenario Outline: User moves a case out of a Campaign
     When I create a "MPAM" case and move it to the "<initialStage>" stage

--- a/src/test/resources/features/mpam/TeamRouting/Campaigns.feature
+++ b/src/test/resources/features/mpam/TeamRouting/Campaigns.feature
@@ -13,19 +13,19 @@ Feature: Campaigns
     And the case should be in the correct MPAM "Campaign" team workstack
     Examples:
       | businessArea           | refType     | stage  |
-#      | UKVI                   | Ministerial | Triage |
-#      | BF                     | Ministerial | Triage |
-#      | IE                     | Ministerial | Triage |
-#      | EUSS                   | Ministerial | Triage |
-#      | HMPO                   | Ministerial | Triage |
-#      | Windrush               | Ministerial | Triage |
+      | UKVI                   | Ministerial | Triage |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
       | Coronavirus (COVID-19) | Ministerial | Triage |
-#      | UKVI                   | Official    | Triage |
-#      | BF                     | Official    | Triage |
-#      | IE                     | Official    | Triage |
-#      | EUSS                   | Official    | Triage |
-#      | HMPO                   | Official    | Triage |
-#      | Windrush               | Official    | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
       | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User moves a case with specific Business Area and Reference Type to Campaign from Triage (On Hold)
@@ -317,7 +317,7 @@ Feature: Campaigns
     And I load the current case
     Then the case should be moved to the "<finalStage>" stage
     Examples:
-    | initialStage  | finalStage  |
-    | Triage        | Triage      |
-    | Draft         | Triage      |
-    | Draft         | Draft       |
+      | initialStage | finalStage |
+      | Triage       | Triage     |
+      | Draft        | Triage     |
+      | Draft        | Draft      |

--- a/src/test/resources/features/mpam/TeamRouting/ContributionRequest.feature
+++ b/src/test/resources/features/mpam/TeamRouting/ContributionRequest.feature
@@ -11,21 +11,21 @@ Feature: Contribution Request
     Then the case should be moved to the "<stage> (Contribution Requested)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage  |
-      | UKVI         | Ministerial   | Triage |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official   | Triage |
-      | BF           | Official   | Triage |
-      | IE           | Official   | Triage |
-      | EUSS         | Official   | Triage |
-      | HMPO         | Official   | Triage |
-      | Windrush     | Official   | Triage |
-      | Coronavirus  | Official   | Triage |
+      | businessArea           | refType     | stage  |
+      | UKVI                   | Ministerial | Triage |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User records that a contribution has been received and returns a case to the Triage stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -37,21 +37,21 @@ Feature: Contribution Request
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage  |
-      | UKVI         | Ministerial   | Triage |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official   | Triage |
-      | BF           | Official   | Triage |
-      | IE           | Official   | Triage |
-      | EUSS         | Official   | Triage |
-      | HMPO         | Official   | Triage |
-      | Windrush     | Official   | Triage |
-      | Coronavirus  | Official   | Triage |
+      | businessArea           | refType     | stage  |
+      | UKVI                   | Ministerial | Triage |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User requests a contribution at Draft stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -60,21 +60,21 @@ Feature: Contribution Request
     Then the case should be moved to the "<stage> (Contribution Requested)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official   | Draft |
-      | BF           | Official   | Draft |
-      | IE           | Official   | Draft |
-      | EUSS         | Official   | Draft |
-      | HMPO         | Official   | Draft |
-      | Windrush     | Official   | Draft |
-      | Coronavirus  | Official   | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |
 
   Scenario Outline: User records that a contribution has been received and returns a case to the Draft stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -86,21 +86,21 @@ Feature: Contribution Request
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official   | Draft |
-      | BF           | Official   | Draft |
-      | IE           | Official   | Draft |
-      | EUSS         | Official   | Draft |
-      | HMPO         | Official   | Draft |
-      | Windrush     | Official   | Draft |
-      | Coronavirus  | Official   | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |
 
   @MPAMRegression1
   Scenario: User requests contribution at Triage-Escalated stage
@@ -119,20 +119,20 @@ Feature: Contribution Request
     And I select the "Contributions Requested" action at the Triage-Escalated stage
     Then the case should be moved to the "<stage> - Escalated (Contribution Requested)" stage
     Examples:
-      | businessArea | refType | stage  |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official   | Triage |
-      | BF           | Official   | Triage |
-      | IE           | Official   | Triage |
-      | EUSS         | Official   | Triage |
-      | HMPO         | Official   | Triage |
-      | Windrush     | Official   | Triage |
-      | Coronavirus  | Official   | Triage |
+      | businessArea           | refType     | stage  |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   @MPAMRegression1
   Scenario: User requests contribution at Draft-Escalated stage
@@ -151,18 +151,18 @@ Feature: Contribution Request
     And I select the "Contributions Requested" action at the Draft-Escalated stage
     Then the case should be moved to the "<stage> - Escalated (Contribution Requested)" stage
     Examples:
-      | businessArea | refType       | stage |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official   | Draft |
-      | BF           | Official   | Draft |
-      | IE           | Official   | Draft |
-      | EUSS         | Official   | Draft |
-      | HMPO         | Official   | Draft |
-      | Windrush     | Official   | Draft |
-      | Coronavirus  | Official   | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |

--- a/src/test/resources/features/mpam/TeamRouting/Escalated.feature
+++ b/src/test/resources/features/mpam/TeamRouting/Escalated.feature
@@ -11,21 +11,21 @@ Feature: Escalated
     Then the case should be moved to the "<stage> (Escalated)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage  |
-      | UKVI         | Ministerial   | Triage |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official   | Triage |
-      | BF           | Official   | Triage |
-      | IE           | Official   | Triage |
-      | EUSS         | Official   | Triage |
-      | HMPO         | Official   | Triage |
-      | Windrush     | Official   | Triage |
-      | Coronavirus  | Official   | Triage |
+      | businessArea           | refType     | stage  |
+      | UKVI                   | Ministerial | Triage |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User escalates a case with specific Business Area and Reference Type at Triage (Contribution Requested) stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -36,21 +36,21 @@ Feature: Escalated
     Then the case should be moved to the "<stage> - Escalated (Contribution Requested)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage  |
-      | UKVI         | Ministerial   | Triage |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official   | Triage |
-      | BF           | Official   | Triage |
-      | IE           | Official   | Triage |
-      | EUSS         | Official   | Triage |
-      | HMPO         | Official   | Triage |
-      | Windrush     | Official   | Triage |
-      | Coronavirus  | Official   | Triage |
+      | businessArea           | refType     | stage  |
+      | UKVI                   | Ministerial | Triage |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User de-escalates a case with specific Business Area and Reference Type at Triage stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -61,21 +61,21 @@ Feature: Escalated
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage  |
-      | UKVI         | Ministerial   | Triage |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official   | Triage |
-      | BF           | Official   | Triage |
-      | IE           | Official   | Triage |
-      | EUSS         | Official   | Triage |
-      | HMPO         | Official   | Triage |
-      | Windrush     | Official   | Triage |
-      | Coronavirus  | Official   | Triage |
+      | businessArea           | refType     | stage  |
+      | UKVI                   | Ministerial | Triage |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User escalates a case with specific Business Area and Reference Type at Draft stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -84,21 +84,21 @@ Feature: Escalated
     Then the case should be moved to the "<stage> (Escalated)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official   | Draft |
-      | BF           | Official   | Draft |
-      | IE           | Official   | Draft |
-      | EUSS         | Official   | Draft |
-      | HMPO         | Official   | Draft |
-      | Windrush     | Official   | Draft |
-      | Coronavirus  | Official   | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |
 
   Scenario Outline: User escalates a case with specific Business Area and Reference Type at Draft (Contribution Requested) stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -109,21 +109,21 @@ Feature: Escalated
     Then the case should be moved to the "<stage> - Escalated (Contribution Requested)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage  |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official   | Draft |
-      | BF           | Official   | Draft |
-      | IE           | Official   | Draft |
-      | EUSS         | Official   | Draft |
-      | HMPO         | Official   | Draft |
-      | Windrush     | Official   | Draft |
-      | Coronavirus  | Official   | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |
 
   Scenario Outline: User de-escalates a case with specific Business Area and Reference Type at Draft stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -134,21 +134,21 @@ Feature: Escalated
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official   | Draft |
-      | BF           | Official   | Draft |
-      | IE           | Official   | Draft |
-      | EUSS         | Official   | Draft |
-      | HMPO         | Official   | Draft |
-      | Windrush     | Official   | Draft |
-      | Coronavirus  | Official   | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |
 
   Scenario Outline: User escalates a case with specific Business Area and Reference Type at QA stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -157,21 +157,21 @@ Feature: Escalated
     Then the case should be moved to the "<stage> (Escalated)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | QA    |
-      | BF           | Ministerial   | QA    |
-      | IE           | Ministerial   | QA    |
-      | EUSS         | Ministerial   | QA    |
-      | HMPO         | Ministerial   | QA    |
-      | Windrush     | Ministerial   | QA    |
-      | Coronavirus  | Ministerial   | QA    |
-      | UKVI         | Official   | QA    |
-      | BF           | Official   | QA    |
-      | IE           | Official   | QA    |
-      | EUSS         | Official   | QA    |
-      | HMPO         | Official   | QA    |
-      | Windrush     | Official   | QA    |
-      | Coronavirus  | Official   | QA    |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | QA    |
+      | BF                     | Ministerial | QA    |
+      | IE                     | Ministerial | QA    |
+      | EUSS                   | Ministerial | QA    |
+      | HMPO                   | Ministerial | QA    |
+      | Windrush               | Ministerial | QA    |
+      | Coronavirus (COVID-19) | Ministerial | QA    |
+      | UKVI                   | Official    | QA    |
+      | BF                     | Official    | QA    |
+      | IE                     | Official    | QA    |
+      | EUSS                   | Official    | QA    |
+      | HMPO                   | Official    | QA    |
+      | Windrush               | Official    | QA    |
+      | Coronavirus (COVID-19) | Official    | QA    |
 
   Scenario Outline: User de-escalates a case with specific Business Area and Reference Type at QA stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -182,18 +182,18 @@ Feature: Escalated
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | QA    |
-      | BF           | Ministerial   | QA    |
-      | IE           | Ministerial   | QA    |
-      | EUSS         | Ministerial   | QA    |
-      | HMPO         | Ministerial   | QA    |
-      | Windrush     | Ministerial   | QA    |
-      | Coronavirus  | Ministerial   | QA    |
-      | UKVI         | Official   | QA    |
-      | BF           | Official   | QA    |
-      | IE           | Official   | QA    |
-      | EUSS         | Official   | QA    |
-      | HMPO         | Official   | QA    |
-      | Windrush     | Official   | QA    |
-      | Coronavirus  | Official   | QA    |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | QA    |
+      | BF                     | Ministerial | QA    |
+      | IE                     | Ministerial | QA    |
+      | EUSS                   | Ministerial | QA    |
+      | HMPO                   | Ministerial | QA    |
+      | Windrush               | Ministerial | QA    |
+      | Coronavirus (COVID-19) | Ministerial | QA    |
+      | UKVI                   | Official    | QA    |
+      | BF                     | Official    | QA    |
+      | IE                     | Official    | QA    |
+      | EUSS                   | Official    | QA    |
+      | HMPO                   | Official    | QA    |
+      | Windrush               | Official    | QA    |
+      | Coronavirus (COVID-19) | Official    | QA    |

--- a/src/test/resources/features/mpam/TeamRouting/MPAMEndToEnd.feature
+++ b/src/test/resources/features/mpam/TeamRouting/MPAMEndToEnd.feature
@@ -9,109 +9,109 @@ Feature: MPAM End To End
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage  |
-      | UKVI         | Ministerial   | Triage |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official   | Triage |
-      | BF           | Official   | Triage |
-      | IE           | Official   | Triage |
-      | EUSS         | Official   | Triage |
-      | HMPO         | Official   | Triage |
-      | Windrush     | Official   | Triage |
-      | Coronavirus  | Official   | Triage |
+      | businessArea           | refType     | stage  |
+      | UKVI                   | Ministerial | Triage |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User moves a case with a specific Business Area and Reference Type to Draft stage
     When I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official   | Draft |
-      | BF           | Official   | Draft |
-      | IE           | Official   | Draft |
-      | EUSS         | Official   | Draft |
-      | HMPO         | Official   | Draft |
-      | Windrush     | Official   | Draft |
-      | Coronavirus  | Official   | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |
 
   Scenario Outline: User moves a case with a specific Business Area and Reference Type to QA stage
     When I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | QA    |
-      | BF           | Ministerial   | QA    |
-      | IE           | Ministerial   | QA    |
-      | EUSS         | Ministerial   | QA    |
-      | HMPO         | Ministerial   | QA    |
-      | Windrush     | Ministerial   | QA    |
-      | Coronavirus  | Ministerial   | QA    |
-      | UKVI         | Official   | QA    |
-      | BF           | Official   | QA    |
-      | IE           | Official   | QA    |
-      | EUSS         | Official   | QA    |
-      | HMPO         | Official   | QA    |
-      | Windrush     | Official   | QA    |
-      | Coronavirus  | Official   | QA    |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | QA    |
+      | BF                     | Ministerial | QA    |
+      | IE                     | Ministerial | QA    |
+      | EUSS                   | Ministerial | QA    |
+      | HMPO                   | Ministerial | QA    |
+      | Windrush               | Ministerial | QA    |
+      | Coronavirus (COVID-19) | Ministerial | QA    |
+      | UKVI                   | Official    | QA    |
+      | BF                     | Official    | QA    |
+      | IE                     | Official    | QA    |
+      | EUSS                   | Official    | QA    |
+      | HMPO                   | Official    | QA    |
+      | Windrush               | Official    | QA    |
+      | Coronavirus (COVID-19) | Official    | QA    |
 
   Scenario Outline: User moves a case with a specific Business Area and Reference Type to its appropriate dispatch stage
     When I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage             |
-      | UKVI         | Ministerial   | Private Office    |
-      | BF           | Ministerial   | Private Office    |
-      | IE           | Ministerial   | Private Office    |
-      | EUSS         | Ministerial   | Private Office    |
-      | HMPO         | Ministerial   | Private Office    |
-      | Windrush     | Ministerial   | Private Office    |
-      | Coronavirus  | Ministerial   | Private Office    |
-      | UKVI         | Official   | Awaiting Dispatch |
-      | BF           | Official   | Awaiting Dispatch |
-      | IE           | Official   | Awaiting Dispatch |
-      | EUSS         | Official   | Awaiting Dispatch |
-      | HMPO         | Official   | Awaiting Dispatch |
-      | Windrush     | Official   | Awaiting Dispatch |
-      | Coronavirus  | Official   | Awaiting Dispatch |
+      | businessArea           | refType     | stage             |
+      | UKVI                   | Ministerial | Private Office    |
+      | BF                     | Ministerial | Private Office    |
+      | IE                     | Ministerial | Private Office    |
+      | EUSS                   | Ministerial | Private Office    |
+      | HMPO                   | Ministerial | Private Office    |
+      | Windrush               | Ministerial | Private Office    |
+      | Coronavirus (COVID-19) | Ministerial | Private Office    |
+      | UKVI                   | Official    | Awaiting Dispatch |
+      | BF                     | Official    | Awaiting Dispatch |
+      | IE                     | Official    | Awaiting Dispatch |
+      | EUSS                   | Official    | Awaiting Dispatch |
+      | HMPO                   | Official    | Awaiting Dispatch |
+      | Windrush               | Official    | Awaiting Dispatch |
+      | Coronavirus (COVID-19) | Official    | Awaiting Dispatch |
 
   @MPAMRegression1 @SmokeTests
   Scenario Outline: User closes a Ministerial case with specific Business Area and Reference Type
     When I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
     Then the case should be closed
     Examples:
-      | businessArea | refType | stage       |
-      | UKVI         | Ministerial   | Case Closed |
-      | BF           | Ministerial   | Case Closed |
-      | IE           | Ministerial   | Case Closed |
-      | EUSS         | Ministerial   | Case Closed |
-      | HMPO         | Ministerial   | Case Closed |
-      | Windrush     | Ministerial   | Case Closed |
-      | Coronavirus  | Ministerial   | Case Closed |
+      | businessArea           | refType     | stage       |
+      | UKVI                   | Ministerial | Case Closed |
+      | BF                     | Ministerial | Case Closed |
+      | IE                     | Ministerial | Case Closed |
+      | EUSS                   | Ministerial | Case Closed |
+      | HMPO                   | Ministerial | Case Closed |
+      | Windrush               | Ministerial | Case Closed |
+      | Coronavirus (COVID-19) | Ministerial | Case Closed |
 
   @MPAMRegression1 @SmokeTests
   Scenario Outline: User closes a Official case with specific Business Area and Reference Type
     When I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
     Then the case should be closed
     Examples:
-      | businessArea | refType | stage       |
-      | UKVI         | Official   | Case Closed |
-      | BF           | Official   | Case Closed |
-      | IE           | Official   | Case Closed |
-      | EUSS         | Official   | Case Closed |
-      | HMPO         | Official   | Case Closed |
-      | Windrush     | Official   | Case Closed |
-      | Coronavirus  | Official   | Case Closed |
+      | businessArea           | refType  | stage       |
+      | UKVI                   | Official | Case Closed |
+      | BF                     | Official | Case Closed |
+      | IE                     | Official | Case Closed |
+      | EUSS                   | Official | Case Closed |
+      | HMPO                   | Official | Case Closed |
+      | Windrush               | Official | Case Closed |
+      | Coronavirus (COVID-19) | Official | Case Closed |

--- a/src/test/resources/features/mpam/TeamRouting/OnHold.feature
+++ b/src/test/resources/features/mpam/TeamRouting/OnHold.feature
@@ -11,21 +11,21 @@ Feature: OnHold
     Then the case should be moved to the "<stage> (On Hold)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage  |
-      | UKVI         | Ministerial   | Triage |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official   | Triage |
-      | BF           | Official   | Triage |
-      | IE           | Official   | Triage |
-      | EUSS         | Official   | Triage |
-      | HMPO         | Official   | Triage |
-      | Windrush     | Official   | Triage |
-      | Coronavirus  | Official   | Triage |
+      | businessArea           | refType     | stage  |
+      | UKVI                   | Ministerial | Triage |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User takes a case with specific Business Area and Reference Type off hold at Triage stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -36,21 +36,21 @@ Feature: OnHold
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage  |
-      | UKVI         | Ministerial   | Triage |
-      | BF           | Ministerial   | Triage |
-      | IE           | Ministerial   | Triage |
-      | EUSS         | Ministerial   | Triage |
-      | HMPO         | Ministerial   | Triage |
-      | Windrush     | Ministerial   | Triage |
-      | Coronavirus  | Ministerial   | Triage |
-      | UKVI         | Official   | Triage |
-      | BF           | Official   | Triage |
-      | IE           | Official   | Triage |
-      | EUSS         | Official   | Triage |
-      | HMPO         | Official   | Triage |
-      | Windrush     | Official   | Triage |
-      | Coronavirus  | Official   | Triage |
+      | businessArea           | refType     | stage  |
+      | UKVI                   | Ministerial | Triage |
+      | BF                     | Ministerial | Triage |
+      | IE                     | Ministerial | Triage |
+      | EUSS                   | Ministerial | Triage |
+      | HMPO                   | Ministerial | Triage |
+      | Windrush               | Ministerial | Triage |
+      | Coronavirus (COVID-19) | Ministerial | Triage |
+      | UKVI                   | Official    | Triage |
+      | BF                     | Official    | Triage |
+      | IE                     | Official    | Triage |
+      | EUSS                   | Official    | Triage |
+      | HMPO                   | Official    | Triage |
+      | Windrush               | Official    | Triage |
+      | Coronavirus (COVID-19) | Official    | Triage |
 
   Scenario Outline: User puts a case with specific Business Area and Reference Type on hold at Draft stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -59,21 +59,21 @@ Feature: OnHold
     Then the case should be moved to the "<stage> (On Hold)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official   | Draft |
-      | BF           | Official   | Draft |
-      | IE           | Official   | Draft |
-      | EUSS         | Official   | Draft |
-      | HMPO         | Official   | Draft |
-      | Windrush     | Official   | Draft |
-      | Coronavirus  | Official   | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |
 
   Scenario Outline: User takes a case with specific Business Area and Reference Type off hold at Draft stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -84,21 +84,21 @@ Feature: OnHold
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | Draft |
-      | BF           | Ministerial   | Draft |
-      | IE           | Ministerial   | Draft |
-      | EUSS         | Ministerial   | Draft |
-      | HMPO         | Ministerial   | Draft |
-      | Windrush     | Ministerial   | Draft |
-      | Coronavirus  | Ministerial   | Draft |
-      | UKVI         | Official   | Draft |
-      | BF           | Official   | Draft |
-      | IE           | Official   | Draft |
-      | EUSS         | Official   | Draft |
-      | HMPO         | Official   | Draft |
-      | Windrush     | Official   | Draft |
-      | Coronavirus  | Official   | Draft |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | Draft |
+      | BF                     | Ministerial | Draft |
+      | IE                     | Ministerial | Draft |
+      | EUSS                   | Ministerial | Draft |
+      | HMPO                   | Ministerial | Draft |
+      | Windrush               | Ministerial | Draft |
+      | Coronavirus (COVID-19) | Ministerial | Draft |
+      | UKVI                   | Official    | Draft |
+      | BF                     | Official    | Draft |
+      | IE                     | Official    | Draft |
+      | EUSS                   | Official    | Draft |
+      | HMPO                   | Official    | Draft |
+      | Windrush               | Official    | Draft |
+      | Coronavirus (COVID-19) | Official    | Draft |
 
   Scenario Outline: User puts a case with specific Business Area and Reference Type on hold at QA stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -107,21 +107,21 @@ Feature: OnHold
     Then the case should be moved to the "<stage> (On Hold)" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | QA    |
-      | BF           | Ministerial   | QA    |
-      | IE           | Ministerial   | QA    |
-      | EUSS         | Ministerial   | QA    |
-      | HMPO         | Ministerial   | QA    |
-      | Windrush     | Ministerial   | QA    |
-      | Coronavirus  | Ministerial   | QA    |
-      | UKVI         | Official   | QA    |
-      | BF           | Official   | QA    |
-      | IE           | Official   | QA    |
-      | EUSS         | Official   | QA    |
-      | HMPO         | Official   | QA    |
-      | Windrush     | Official   | QA    |
-      | Coronavirus  | Official   | QA    |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | QA    |
+      | BF                     | Ministerial | QA    |
+      | IE                     | Ministerial | QA    |
+      | EUSS                   | Ministerial | QA    |
+      | HMPO                   | Ministerial | QA    |
+      | Windrush               | Ministerial | QA    |
+      | Coronavirus (COVID-19) | Ministerial | QA    |
+      | UKVI                   | Official    | QA    |
+      | BF                     | Official    | QA    |
+      | IE                     | Official    | QA    |
+      | EUSS                   | Official    | QA    |
+      | HMPO                   | Official    | QA    |
+      | Windrush               | Official    | QA    |
+      | Coronavirus (COVID-19) | Official    | QA    |
 
   Scenario Outline: User takes a case with specific Business Area and Reference Type off hold at QA stage
     And I create a MPAM case with "<businessArea>" as the Business Area and "<refType>" as the Reference Type and move it to the "<stage>" stage
@@ -132,18 +132,18 @@ Feature: OnHold
     Then the case should be moved to the "<stage>" stage
     And the case should be in the correct MPAM "<stage>" team workstack
     Examples:
-      | businessArea | refType | stage |
-      | UKVI         | Ministerial   | QA    |
-      | BF           | Ministerial   | QA    |
-      | IE           | Ministerial   | QA    |
-      | EUSS         | Ministerial   | QA    |
-      | HMPO         | Ministerial   | QA    |
-      | Windrush     | Ministerial   | QA    |
-      | Coronavirus  | Ministerial   | QA    |
-      | UKVI         | Official   | QA    |
-      | BF           | Official   | QA    |
-      | IE           | Official   | QA    |
-      | EUSS         | Official   | QA    |
-      | HMPO         | Official   | QA    |
-      | Windrush     | Official   | QA    |
-      | Coronavirus  | Official   | QA    |
+      | businessArea           | refType     | stage |
+      | UKVI                   | Ministerial | QA    |
+      | BF                     | Ministerial | QA    |
+      | IE                     | Ministerial | QA    |
+      | EUSS                   | Ministerial | QA    |
+      | HMPO                   | Ministerial | QA    |
+      | Windrush               | Ministerial | QA    |
+      | Coronavirus (COVID-19) | Ministerial | QA    |
+      | UKVI                   | Official    | QA    |
+      | BF                     | Official    | QA    |
+      | IE                     | Official    | QA    |
+      | EUSS                   | Official    | QA    |
+      | HMPO                   | Official    | QA    |
+      | Windrush               | Official    | QA    |
+      | Coronavirus (COVID-19) | Official    | QA    |


### PR DESCRIPTION
Changed businessArea wording from 'Coronavirus' to 'Coronavirus (COVID-19)' on scenarios, added logic to enable proper assertion of MPAM team when the businessArea 'Coronavirus (COVID-19)' is selected