### PR TITLE
RegressionFix for FOI and WCS

### DIFF
--- a/src/test/java/com/hocs/test/pages/decs/Correspondents.java
+++ b/src/test/java/com/hocs/test/pages/decs/Correspondents.java
@@ -56,7 +56,11 @@ public class Correspondents extends BasePage {
     }
 
     public void enterCorrespondentFullName(String fullName) {
-        enterSpecificTextIntoTextFieldWithHeading(fullName, "Full name");
+        if (foiCase()) {
+            enterSpecificTextIntoTextFieldWithHeading(fullName, "Full Name");
+        } else {
+            enterSpecificTextIntoTextFieldWithHeading(fullName, "Full name");
+        }
         setSessionVariable("correspondentFullName").to(fullName);
     }
 
@@ -71,7 +75,12 @@ public class Correspondents extends BasePage {
     }
 
     public void enterCorrespondentTownOrCity(String townOrCity) {
-        enterSpecificTextIntoTextFieldWithHeading(townOrCity, "Town or city");
+        if (foiCase()) {
+            enterSpecificTextIntoTextFieldWithHeading(townOrCity, "Town or City");
+        }
+        else {
+            enterSpecificTextIntoTextFieldWithHeading(townOrCity, "Town or city");
+        }
         setSessionVariable("correspondentTownOrCity").to(townOrCity);
     }
 

--- a/src/test/java/com/hocs/test/pages/wcs/Rejected.java
+++ b/src/test/java/com/hocs/test/pages/wcs/Rejected.java
@@ -19,7 +19,7 @@ public class Rejected extends BasePage {
     public WebElementFacade reviewEligibilityDecisionIsRequiredErrorMessage;
 
     public void selectToSendClaimToTier1Review() {
-        selectSpecificRadioButton("Yes, send to Tier 1 review");
+        selectSpecificRadioButton("Yes, send to Tier 1 review ");
         clickConfirmButton();
     }
 


### PR DESCRIPTION
RegressionFix for FOI and WCS. For FOI the case change is not implemented so added an if else statement to separate FOI from the rest. WCS added space in selectToSendClaimToTier1Review method to match the search